### PR TITLE
[Core]: Added a way to disable the hardware plugin receive threads

### DIFF
--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -103,6 +103,10 @@ public:
 	/// @returns `true` if the callback was removed, `false` if no callback matched the two parameters
 	static bool remove_can_lib_update_callback(void (*callback)(), void *parentPointer);
 
+	/// @brief Stops only the recieve threads for each channel. Useful for testing. Keeps the Tx and main threads running.
+	/// @returns `true` if the receive threads were joined
+	static bool stop_recieve_threads();
+
 private:
 	/// @brief A class to store information about CAN lib update callbacks
 	class CanLibUpdateCallbackInfo
@@ -186,6 +190,7 @@ private:
 	static std::condition_variable threadConditionVariable; ///< A condition variable to allow for signaling the CAN thread from `periodicUpdateThread`
 	static std::atomic_bool threadsStarted; ///< Stores if `start` has been called yet
 	static std::atomic_bool canLibNeedsUpdate; ///< Stores if the CAN thread needs to update the CAN stack this iteration
+	static std::atomic_bool stopRxThreads; ///< Disables receive threads for testing purposes
 	static std::uint32_t canLibUpdatePeriod; ///< The period between calls to the CAN stack update function in milliseconds
 };
 

--- a/hardware_integration/src/virtual_can_plugin.cpp
+++ b/hardware_integration/src/virtual_can_plugin.cpp
@@ -77,7 +77,7 @@ void VirtualCANPlugin::write_frame_as_if_received(const isobus::HardwareInterfac
 bool VirtualCANPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
 {
 	std::unique_lock<std::mutex> lock(mutex);
-	ourDevice->condition.wait(lock, [this] { return !running || !ourDevice->queue.empty(); });
+	ourDevice->condition.wait_for(lock, std::chrono::milliseconds(100), [this] { return !running || !ourDevice->queue.empty(); });
 	if (!ourDevice->queue.empty())
 	{
 		canFrame = ourDevice->queue.front();

--- a/test/hardware_interface_tests.cpp
+++ b/test/hardware_interface_tests.cpp
@@ -76,5 +76,10 @@ TEST(HARDWARE_INTERFACE_TESTS, ReceiveMessageFromHardware)
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 	EXPECT_EQ(message_count, 1);
 
+	// Test disabling Rx threads
+	EXPECT_EQ(true, CANHardwareInterface::stop_recieve_threads());
+
 	CANHardwareInterface::stop();
+
+	EXPECT_EQ(false, CANHardwareInterface::stop_recieve_threads());
 }


### PR DESCRIPTION
I was having a lot of trouble while testing task controller message encoding because the Rx thread for the virtual can plugin could come along and read messages out of the queues before I could manually read them to verify their content. So, these changes allow us to temporarily stop the Rx threads so that we can synchronously receive messages while running tests to ensure we never randomly lose messages (which we were before). I also added a timeout value to the virtual can read function to 100% avoid an infinite wait. Generally this should not affect anything negatively as the Rx thread will just re-try the read, but it has the upside of preventing a hard lock up while running tests if a message fails to send or something.