### PR TITLE
Actually pass the parent pointer to periodic updates.

### DIFF
--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -20,7 +20,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *parentPointer)
+void update_CAN_network(void *)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -20,7 +20,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network()
+void update_CAN_network(void *parentPointer)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -42,7 +42,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network()
+void update_CAN_network(void *parentPointer)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -42,7 +42,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *parentPointer)
+void update_CAN_network(void *)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -23,7 +23,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network()
+void update_CAN_network(void *parentPointer)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -23,7 +23,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *parentPointer)
+void update_CAN_network(void *)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -24,7 +24,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network()
+void update_CAN_network(void *parentPointer)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -24,7 +24,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *parentPointer)
+void update_CAN_network(void *)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/vt_aux_n/main.cpp
+++ b/examples/vt_aux_n/main.cpp
@@ -26,7 +26,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network()
+void update_CAN_network(void *parentPointer)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/vt_aux_n/main.cpp
+++ b/examples/vt_aux_n/main.cpp
@@ -26,7 +26,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *parentPointer)
+void update_CAN_network(void *)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/vt_version_3_object_pool/main.cpp
+++ b/examples/vt_version_3_object_pool/main.cpp
@@ -26,7 +26,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network()
+void update_CAN_network(void *parentPointer)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/examples/vt_version_3_object_pool/main.cpp
+++ b/examples/vt_version_3_object_pool/main.cpp
@@ -26,7 +26,7 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *parentPointer)
+void update_CAN_network(void *)
 {
 	isobus::CANNetworkManager::CANNetwork.update();
 }

--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -95,13 +95,13 @@ public:
 	/// @param[in] callback The callback to add
 	/// @param[in] parentPointer Generic context variable, usually a pointer to the owner class for this callback
 	/// @returns `true` if the callback was added, `false` if it was already in the list
-	static bool add_can_lib_update_callback(void (*callback)(), void *parentPointer);
+	static bool add_can_lib_update_callback(void (*callback)(void *parentPointer), void *parentPointer);
 
 	/// @brief Removes a periodic update callback
 	/// @param[in] callback The callback to remove
 	/// @param[in] parentPointer Generic context variable, usually a pointer to the owner class for this callback
 	/// @returns `true` if the callback was removed, `false` if no callback matched the two parameters
-	static bool remove_can_lib_update_callback(void (*callback)(), void *parentPointer);
+	static bool remove_can_lib_update_callback(void (*callback)(void *parentPointer), void *parentPointer);
 
 private:
 	/// @brief A class to store information about CAN lib update callbacks
@@ -112,7 +112,7 @@ private:
 		/// @param obj the object to compare against
 		bool operator==(const CanLibUpdateCallbackInfo &obj) const;
 
-		void (*callback)() = nullptr; ///< The callback
+		void (*callback)(void *parentPointer) = nullptr; ///< The callback
 		void *parent = nullptr; ///< Context variable, the owner of the callback
 	};
 

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -275,7 +275,7 @@ void CANHardwareInterface::set_can_driver_update_period(std::uint32_t value)
 	canLibUpdatePeriod = value;
 }
 
-bool CANHardwareInterface::add_can_lib_update_callback(void (*callback)(), void *parentPointer)
+bool CANHardwareInterface::add_can_lib_update_callback(void (*callback)(void *parentPointer), void *parentPointer)
 {
 	std::lock_guard<std::mutex> lock(periodicUpdateCallbacksMutex);
 
@@ -292,7 +292,7 @@ bool CANHardwareInterface::add_can_lib_update_callback(void (*callback)(), void 
 	return false;
 }
 
-bool CANHardwareInterface::remove_can_lib_update_callback(void (*callback)(), void *parentPointer)
+bool CANHardwareInterface::remove_can_lib_update_callback(void (*callback)(void *parentPointer), void *parentPointer)
 {
 	std::lock_guard<std::mutex> lock(periodicUpdateCallbacksMutex);
 
@@ -362,7 +362,7 @@ void CANHardwareInterface::can_thread_function()
 				{
 					if (nullptr != periodicUpdateCallbacks[j].callback)
 					{
-						periodicUpdateCallbacks[j].callback();
+						periodicUpdateCallbacks[j].callback(periodicUpdateCallbacks[j].parent);
 					}
 				}
 				periodicUpdateCallbacksMutex.unlock();

--- a/test/address_claim_tests.cpp
+++ b/test/address_claim_tests.cpp
@@ -23,7 +23,7 @@ TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 	CANHardwareInterface::start();
 
 	CANHardwareInterface::add_can_lib_update_callback(
-	  [] {
+	  [](void *) {
 		  CANNetworkManager::CANNetwork.update();
 	  },
 	  nullptr);


### PR DESCRIPTION
`add_can_lib_update_callback`, like many other callback methods, takes a `parentPointer` and stores said pointer in `CanLibUpdateCallbackInfo`.  However, unlike basically every other example of callbacks that I could find this meta-data is not actually passed to the callback itself, in fact the only place it seems to be used is in `remove_can_lib_update_callback` to confirm that you're removing the correct instance.

This updates the signatures and calls to actually pass the parent pointer to the callbacks themselves.