### PR TITLE
[Meta]: Move tutorial/getting started to ReadTheDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-Check out the [tutorial website](https://delgrossoengineering.com/isobus-tutorial/index.html) for information on ISOBUS basics, how to download this library, and how to use it. The tutorials contain in-depth examples and explanations to help get your ISOBUS or J1939 project going quickly.
+Check out the [tutorial website](https://isobus-plus-plus.readthedocs.io/en/latest/) for information on ISOBUS basics, how to download this library, and how to use it. The tutorials contain in-depth examples and explanations to help get your ISOBUS or J1939 project going quickly.
 
 ## Compilation
 

--- a/sphinx/source/Installation.rst
+++ b/sphinx/source/Installation.rst
@@ -74,4 +74,4 @@ Non-CMake:
 
 If you are not using CMake, just make sure to add all the files from the 'ISO11783-CAN-Stack/isobus' folder, the 'ISO11783-CAN-Stack/hardware_integration' folder, and the 'ISO11783-CAN-Stack/utility' folder to your project so they all get compiled. 
 
-You'll want to make sure the 'ISO11783-CAN-Stack/isobus/include/isobus/isobus' folder is part of your include pathm as well as 'ISO11783-CAN-Stack/utility/include/isobus/utility' and 'ISO11783-CAN-Stack/hardware_integration/include/isobus/hardware_integration'.
+You'll want to make sure the 'ISO11783-CAN-Stack/isobus/include/isobus/isobus' folder is part of your include path as well as 'ISO11783-CAN-Stack/utility/include/isobus/utility' and 'ISO11783-CAN-Stack/hardware_integration/include/isobus/hardware_integration'.


### PR DESCRIPTION
ReadTheDocs has better uptime than my internet at my house, and integrates well with GitHub.
Plus, I was using a theme from them anyways.
Hopefully this will make it easier for people to access the examples and docs from outside the USA.