### PR TITLE
Add optional destination function filtering for partner control function responses.

### DIFF
--- a/isobus/include/isobus/isobus/can_callbacks.hpp
+++ b/isobus/include/isobus/isobus/can_callbacks.hpp
@@ -66,7 +66,7 @@ namespace isobus
 		/// @param[in] parameterGroupNumber The PGN you want to register a callback for
 		/// @param[in] callback The function you want the stack to call when it gets receives a message with a matching PGN
 		/// @param[in] parentPointer A generic variable that can provide context to which object the callback was meant for
-		ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer);
+		ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, InternalControlFunction *destinationFunction);
 
 		/// @brief A copy constructor for holding callback data
 		/// @param[in] oldObj The object to copy from
@@ -90,6 +90,10 @@ namespace isobus
 		/// @returns The callback pointer for this data object
 		CANLibCallback get_callback() const;
 
+		/// @brief Returns the optional destination internal function
+		/// @returns The optional destination internal function for this data object
+		InternalControlFunction *get_destination_control_function() const;
+
 		/// @brief Returns the parent pointer for this data object
 		void *get_parent() const;
 
@@ -97,6 +101,7 @@ namespace isobus
 		CANLibCallback mCallback; ///< The callback that will get called when a matching PGN is received
 		std::uint32_t mParameterGroupNumber; ///< The PGN assocuiated with this callback
 		void *mParent; ///< A generic variable that can provide context to which object the callback was meant for
+		InternalControlFunction *mDestinationFunction; ///< An optional filter for source/destination function pairs
 	};
 } // namespace isobus
 

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -58,32 +58,44 @@ namespace isobus
 		void add_control_function(std::uint8_t CANPort, ControlFunction *newControlFunction, std::uint8_t CFAddress, CANLibBadge<AddressClaimStateMachine>);
 
 		/// @brief This is how you register a callback for any PGN destined for the global address (0xFF)
+		/// @details You may pass a destination `InternalControlFunction`, which will filter for only those messages
+		/// that target this source/destination pair (see https://github.com/ad3154/Isobus-plus-plus/issues/206).
 		/// @param[in] parameterGroupNumber The PGN you want to register for
 		/// @param[in] callback The callback that will be called when parameterGroupNumber is recieved from the global address (0xFF)
 		/// @param[in] parent A generic context variable that helps identify what object the callback is destined for. Can be nullptr if you don't want to use it.
-		void add_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
+		void add_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction = nullptr);
 
 		/// @brief This is how you remove a callback for any PGN destined for the global address (0xFF)
+		/// @details You may pass a destination `InternalControlFunction`, which will filter for only those messages
+		/// that target this source/destination pair (see https://github.com/ad3154/Isobus-plus-plus/issues/206).
 		/// @param[in] parameterGroupNumber The PGN of the callback to remove
 		/// @param[in] callback The callback that will be removed
 		/// @param[in] parent A generic context variable that helps identify what object the callback was destined for
-		void remove_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
+		void remove_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction = nullptr);
 
 		/// @brief Returns the number of global PGN callbacks that have been registered with the network manager
 		/// @returns The number of global PGN callbacks that have been registered with the network manager
 		std::uint32_t get_number_global_parameter_group_number_callbacks() const;
 
 		/// @brief Registers a callback for ANY control function sending the associated PGN
+		/// @details You may pass a destination `InternalControlFunction`, which will filter for only those messages
+		/// that target this source/destination pair (see https://github.com/ad3154/Isobus-plus-plus/issues/206).
 		/// @param[in] parameterGroupNumber The PGN you want to register for
 		/// @param[in] callback The callback that will be called when parameterGroupNumber is recieved from any control function
 		/// @param[in] parent A generic context variable that helps identify what object the callback is destined for. Can be nullptr if you don't want to use it.
-		void add_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
+		void add_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction = nullptr);
 
 		/// @brief This is how you remove a callback added with add_any_control_function_parameter_group_number_callback
+		/// @details You may pass a destination `InternalControlFunction`, which will filter for only those messages
+		/// that target this source/destination pair (see https://github.com/ad3154/Isobus-plus-plus/issues/206).
 		/// @param[in] parameterGroupNumber The PGN of the callback to remove
 		/// @param[in] callback The callback that will be removed
 		/// @param[in] parent A generic context variable that helps identify what object the callback was destined for
-		void remove_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
+		void remove_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction = nullptr);
 
 		/// @brief Returns an internal control function if the passed-in control function is an internal type
 		/// @returns An internal control function casted from the passed in control function
@@ -133,18 +145,24 @@ namespace isobus
 		friend class CANLibProtocol;
 
 		/// @brief Adds a PGN callback for a protocol class
+		/// @details You may pass a destination `InternalControlFunction`, which will filter for only those messages
+		/// that target this source/destination pair (see https://github.com/ad3154/Isobus-plus-plus/issues/206).
 		/// @param[in] parameterGroupNumber The PGN to register for
 		/// @param[in] callback The callback to call when the PGN is received
 		/// @param[in] parentPointer A generic context variable that helps identify what object the callback was destined for
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
 		/// @returns `true` if the callback was added, otherwise `false`
-		bool add_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer);
+		bool add_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, InternalControlFunction *destinationFunction = nullptr);
 
 		/// @brief Removes a PGN callback for a protocol class
+		/// @details You may pass a destination `InternalControlFunction`, which will filter for only those messages
+		/// that target this source/destination pair (see https://github.com/ad3154/Isobus-plus-plus/issues/206).
 		/// @param[in] parameterGroupNumber The PGN to register for
 		/// @param[in] callback The callback to call when the PGN is received
 		/// @param[in] parentPointer A generic context variable that helps identify what object the callback was destined for
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
 		/// @returns `true` if the callback was removed, otherwise `false`
-		bool remove_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer);
+		bool remove_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, InternalControlFunction *destinationFunction = nullptr);
 
 		/// @brief Sends a CAN message using raw addresses. Used only by the stack.
 		/// @param[in] portIndex The CAN channel index to send the message from

--- a/isobus/include/isobus/isobus/can_partnered_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_partnered_control_function.hpp
@@ -51,16 +51,20 @@ namespace isobus
 		/// destined for. Whatever you pass in `parent` will be passed back to you in the callback. In theory, you could use
 		/// that variable for passing any arbitrary data through the callback also.
 		/// You can add as many callbacks as you want, and can use the same function for multiple PGNs if you want.
+		/// Also optionally you may pass a destination `InternalControlFunction`, which will filter for only those messages
+		/// that target this source/destination pair (see https://github.com/ad3154/Isobus-plus-plus/issues/206).
 		/// @param[in] parameterGroupNumber The PGN you want to use to communicate, or `CANLibParameterGroupNumber::Any`
 		/// @param[in] callback The function you want to get called when a message is received with parameterGroupNumber from this CF
 		/// @param[in] parent A generic context variable that helps identify what object the callback was destined for
-		void add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
+		void add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction = nullptr);
 
 		/// @brief Removes a callback matching *exactly* the parameters passed in
 		/// @param[in] parameterGroupNumber The PGN associated with the callback being removed
 		/// @param[in] callback The callback function being removed
 		/// @param[in] parent A generic context variable that helps identify what object the callback was destined for
-		void remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
+		void remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction = nullptr);
 
 		/// @brief Returns the number of parameter group number callbacks associated with this control function
 		/// @returns The number of parameter group number callbacks associated with this control function

--- a/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
+++ b/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
@@ -46,16 +46,22 @@ namespace isobus
 		void initialize(CANLibBadge<CANNetworkManager>) override;
 
 		/// @brief Similar to add_parameter_group_number_callback but tells the stack to parse those PGNs as Fast Packet
+		/// @details You may pass a destination `InternalControlFunction`, which will filter for only those messages
+		/// that target this source/destination pair (see https://github.com/ad3154/Isobus-plus-plus/issues/206).
 		/// @param[in] parameterGroupNumber The PGN to parse as fast packet
 		/// @param[in] callback The callback that the stack will call when a matching message is received
 		/// @param[in] parent Generic context variable
-		void register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
+		void register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction = nullptr);
 
-		// @brief Removes a callback previously added with register_multipacket_message_callback
+		/// @brief Removes a callback previously added with register_multipacket_message_callback
+		/// @details You may pass a destination `InternalControlFunction`, which will filter for only those messages
+		/// that target this source/destination pair (see https://github.com/ad3154/Isobus-plus-plus/issues/206).
 		/// @param[in] parameterGroupNumber The PGN to parse as fast packet
 		/// @param[in] callback The callback that the stack will call when a matching message is received
 		/// @param[in] parent Generic context variable
-		void remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] destinationFunction An optional internal function destination to filter messages by
+		void remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction = nullptr);
 
 		/// @brief Used to send CAN messages using fast packet
 		/// @details You have to use this function instead of the network manager

--- a/isobus/src/can_callbacks.cpp
+++ b/isobus/src/can_callbacks.cpp
@@ -10,10 +10,11 @@
 
 namespace isobus
 {
-	ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer) :
+	ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, InternalControlFunction *destinationFunction) :
 	  mCallback(callback),
 	  mParameterGroupNumber(parameterGroupNumber),
-	  mParent(parentPointer)
+	  mParent(parentPointer),
+	  mDestinationFunction(destinationFunction)
 	{
 	}
 
@@ -22,13 +23,15 @@ namespace isobus
 		mCallback = oldObj.mCallback;
 		mParameterGroupNumber = oldObj.mParameterGroupNumber;
 		mParent = oldObj.mParent;
+		mDestinationFunction = oldObj.mDestinationFunction;
 	}
 
 	bool ParameterGroupNumberCallbackData::operator==(const ParameterGroupNumberCallbackData &obj)
 	{
 		return ((obj.mCallback == this->mCallback) &&
 		        (obj.mParameterGroupNumber == this->mParameterGroupNumber) &&
-		        (obj.mParent == this->mParent));
+		        (obj.mParent == this->mParent) &&
+		        (obj.mDestinationFunction == this->mDestinationFunction));
 	}
 
 	ParameterGroupNumberCallbackData &ParameterGroupNumberCallbackData::operator=(const ParameterGroupNumberCallbackData &obj)
@@ -47,6 +50,11 @@ namespace isobus
 	CANLibCallback ParameterGroupNumberCallbackData::get_callback() const
 	{
 		return mCallback;
+	}
+	
+	InternalControlFunction *ParameterGroupNumberCallbackData::get_destination_control_function() const
+	{
+		return mDestinationFunction;
 	}
 
 	void *ParameterGroupNumberCallbackData::get_parent() const

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -61,14 +61,14 @@ namespace isobus
 		}
 	}
 
-	void PartneredControlFunction::add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
+	void PartneredControlFunction::add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction)
 	{
-		parameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent));
+		parameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent, destinationFunction));
 	}
 
-	void PartneredControlFunction::remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
+	void PartneredControlFunction::remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction)
 	{
-		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent);
+		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent, destinationFunction);
 		auto callbackLocation = std::find(parameterGroupNumberCallbacks.begin(), parameterGroupNumberCallbacks.end(), tempObject);
 		if (parameterGroupNumberCallbacks.end() != callbackLocation)
 		{

--- a/isobus/src/nmea2000_fast_packet_protocol.cpp
+++ b/isobus/src/nmea2000_fast_packet_protocol.cpp
@@ -53,15 +53,15 @@ namespace isobus
 		}
 	}
 
-	void FastPacketProtocol::register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
+	void FastPacketProtocol::register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction)
 	{
-		parameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent));
+		parameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent, destinationFunction));
 		CANNetworkManager::CANNetwork.add_protocol_parameter_group_number_callback(parameterGroupNumber, process_message, this);
 	}
 
-	void FastPacketProtocol::remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
+	void FastPacketProtocol::remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *destinationFunction)
 	{
-		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent);
+		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent, destinationFunction);
 		auto callbackLocation = std::find(parameterGroupNumberCallbacks.begin(), parameterGroupNumberCallbacks.end(), tempObject);
 		if (parameterGroupNumberCallbacks.end() != callbackLocation)
 		{


### PR DESCRIPTION
Basically implementing the outcome of #206, so you can listen for responses only to certain source internal functions.