### PR TITLE
[Core]: Address some code smells

### DIFF
--- a/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
+++ b/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
@@ -235,7 +235,7 @@ void InnoMakerUSB2CANWindowsPlugin::open()
 
 			default:
 			{
-				isobus::CANStackLogger::error("[InnoMaker-Windows] Unsupported baudrate with index " + std::to_string(baudrate) + " in InnoMakerUSB2CANWindowsPlugin::Baudrate enum.");
+				isobus::CANStackLogger::error("[InnoMaker-Windows] Unsupported baudrate with index " + isobus::to_string(baudrate) + " in InnoMakerUSB2CANWindowsPlugin::Baudrate enum.");
 				return;
 			}
 			break;
@@ -245,7 +245,7 @@ void InnoMakerUSB2CANWindowsPlugin::open()
 	}
 	else
 	{
-		isobus::CANStackLogger::error("[InnoMaker-Windows] No device found on channel " + std::to_string(channel));
+		isobus::CANStackLogger::error("[InnoMaker-Windows] No device found on channel " + isobus::to_string(channel));
 	}
 }
 
@@ -272,7 +272,7 @@ bool InnoMakerUSB2CANWindowsPlugin::read_frame(isobus::HardwareInterfaceCANFrame
 		InnoMakerUsb2CanLib::innomaker_tx_context *txc = driverInstance->innomaker_get_tx_context(txContexts.get(), frame.echo_id);
 		if (nullptr == txc)
 		{
-			isobus::CANStackLogger::warn("[InnoMaker-Windows] Received frame with bad echo ID: " + std::to_string(static_cast<int>(frame.echo_id)));
+			isobus::CANStackLogger::warn("[InnoMaker-Windows] Received frame with bad echo ID: " + isobus::to_string(static_cast<int>(frame.echo_id)));
 			return false;
 		}
 		driverInstance->innomaker_free_tx_context(txc);

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -57,6 +57,10 @@ set(ISOBUS_INCLUDE
     "can_stack_logger.hpp"
     "can_network_configuration.hpp"
     "can_callbacks.hpp"
+    "can_frame.hpp"
+    "can_hardware_abstraction.hpp"
+    "can_internal_control_function.hpp"
+    "can_partnered_control_function.hpp"
     "isobus_virtual_terminal_client.hpp"
     "can_extended_transport_protocol.hpp"
     "isobus_diagnostic_protocol.hpp"
@@ -66,6 +70,7 @@ set(ISOBUS_INCLUDE
     "isobus_language_command_interface.hpp"
     "isobus_standard_data_description_indices.hpp"
     "isobus_task_controller_client_objects.hpp"
+    "isobus_task_controller_client.hpp"
     "isobus_device_descriptor_object_pool.hpp")
 
 # Prepend the include directory path to all the include files

--- a/isobus/include/isobus/isobus/can_NAME.hpp
+++ b/isobus/include/isobus/isobus/can_NAME.hpp
@@ -347,7 +347,7 @@ namespace isobus
 		bool operator==(const NAME &obj) const;
 
 		/// @brief A structure that tracks the pair of a NAME parameter and associated value
-		typedef std::pair<const NAMEParameters, const std::uint32_t> NameParameterFilter;
+		using NameParameterFilter = std::pair<const NAMEParameters, const std::uint32_t>;
 
 		/// @brief Constructor for a NAME
 		/// @param[in] rawNAMEData The raw 64 bit NAME of an ECU

--- a/isobus/include/isobus/isobus/can_address_claim_state_machine.hpp
+++ b/isobus/include/isobus/isobus/can_address_claim_state_machine.hpp
@@ -11,6 +11,7 @@
 #define CAN_ADDRESS_CLAIM_STATE_MACHINE_HPP
 
 #include "isobus/isobus/can_NAME.hpp"
+#include "isobus/isobus/can_constants.hpp"
 
 namespace isobus
 {
@@ -80,20 +81,20 @@ namespace isobus
 		void set_current_state(State value);
 
 		/// @brief Sends the PGN request for the address claim PGN
-		bool send_request_to_claim();
+		bool send_request_to_claim() const;
 
 		/// @brief Sends the address claim message
 		/// @param[in] address The address to claim
 		bool send_address_claim(std::uint8_t address);
 
 		NAME m_isoname; ///< The ISO NAME to claim as
-		State m_currentState; ///< The address claim state machine state
-		std::uint32_t m_timestamp_ms; ///< A generic timestamp in milliseconds used to find timeouts
+		State m_currentState = State::None; ///< The address claim state machine state
+		std::uint32_t m_timestamp_ms = 0; ///< A generic timestamp in milliseconds used to find timeouts
 		std::uint8_t m_portIndex; ///< The CAN channel index to claim on
 		std::uint8_t m_preferredAddress; ///< The address we'd prefer to claim as (we may not get it)
 		std::uint8_t m_randomClaimDelay_ms; ///< The random delay as required by the ISO11783 standard
-		std::uint8_t m_claimedAddress; ///< The actual address we ended up claiming
-		bool m_enabled; ///<  Enable/disable state for this state machine
+		std::uint8_t m_claimedAddress = NULL_CAN_ADDRESS; ///< The actual address we ended up claiming
+		bool m_enabled = true; ///<  Enable/disable state for this state machine
 	};
 
 } // namespace isobus

--- a/isobus/include/isobus/isobus/can_badge.hpp
+++ b/isobus/include/isobus/isobus/can_badge.hpp
@@ -31,7 +31,7 @@ namespace isobus
 	private:
 		friend T; ///< Our best friend, T
 		//! @brief An empty function for our best friend <T>
-		CANLibBadge(){};
+		CANLibBadge() = default;
 	};
 	//! @endcond
 

--- a/isobus/include/isobus/isobus/can_callbacks.hpp
+++ b/isobus/include/isobus/isobus/can_callbacks.hpp
@@ -30,29 +30,29 @@ namespace isobus
 	/// @brief A callback for control functions to get CAN messages
 	typedef void (*CANLibCallback)(CANMessage *message, void *parentPointer);
 	/// @brief A callback to get chunks of data for transfer by a protocol
-	typedef bool (*DataChunkCallback)(std::uint32_t callbackIndex,
-	                                  std::uint32_t bytesOffset,
-	                                  std::uint32_t numberOfBytesNeeded,
-	                                  std::uint8_t *chunkBuffer,
-	                                  void *parentPointer);
-	/// @brief A callback for when a transmit is completed by the stack
-	typedef void (*TransmitCompleteCallback)(std::uint32_t parameterGroupNumber,
-	                                         std::uint32_t dataLength,
-	                                         InternalControlFunction *sourceControlFunction,
-	                                         ControlFunction *destinationControlFunction,
-	                                         bool successful,
-	                                         void *parentPointer);
-	/// @brief A callback for handling a PGN request
-	typedef bool (*PGNRequestCallback)(std::uint32_t parameterGroupNumber,
-	                                   ControlFunction *requestingControlFunction,
-	                                   bool &acknowledge,
-	                                   AcknowledgementType &acknowledgeType,
+	using DataChunkCallback = bool (*)(std::uint32_t callbackIndex,
+	                                   std::uint32_t bytesOffset,
+	                                   std::uint32_t numberOfBytesNeeded,
+	                                   std::uint8_t *chunkBuffer,
 	                                   void *parentPointer);
+	/// @brief A callback for when a transmit is completed by the stack
+	using TransmitCompleteCallback = void (*)(std::uint32_t parameterGroupNumber,
+	                                          std::uint32_t dataLength,
+	                                          InternalControlFunction *sourceControlFunction,
+	                                          ControlFunction *destinationControlFunction,
+	                                          bool successful,
+	                                          void *parentPointer);
+	/// @brief A callback for handling a PGN request
+	using PGNRequestCallback = bool (*)(std::uint32_t parameterGroupNumber,
+	                                    ControlFunction *requestingControlFunction,
+	                                    bool &acknowledge,
+	                                    AcknowledgementType &acknowledgeType,
+	                                    void *parentPointer);
 	/// @brief A callback for handling a request for repetition rate for a specific PGN
-	typedef bool (*PGNRequestForRepetitionRateCallback)(std::uint32_t parameterGroupNumber,
-	                                                    ControlFunction *requestingControlFunction,
-	                                                    std::uint32_t repetitionRate,
-	                                                    void *parentPointer);
+	using PGNRequestForRepetitionRateCallback = bool (*)(std::uint32_t parameterGroupNumber,
+	                                                     ControlFunction *requestingControlFunction,
+	                                                     std::uint32_t repetitionRate,
+	                                                     void *parentPointer);
 
 	//================================================================================================
 	/// @class ParameterGroupNumberCallbackData
@@ -75,7 +75,7 @@ namespace isobus
 		/// @brief Equality operator for this class
 		/// @param[in] obj The object to check equality against
 		/// @returns true if the objects have equivalent data
-		bool operator==(const ParameterGroupNumberCallbackData &obj);
+		bool operator==(const ParameterGroupNumberCallbackData &obj) const;
 
 		/// @brief Assignment operator for this class
 		/// @param[in] obj The object to assign data from

--- a/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
@@ -109,7 +109,7 @@ namespace isobus
 		ExtendedTransportProtocolManager();
 
 		/// @brief The destructor for the TransportProtocolManager
-		virtual ~ExtendedTransportProtocolManager();
+		~ExtendedTransportProtocolManager() final;
 
 		/// @brief The protocol's initializer function
 		void initialize(CANLibBadge<CANNetworkManager>) override;
@@ -182,14 +182,14 @@ namespace isobus
 		/// @param[in] source The source control function for the session
 		/// @param[in] destination The destination control function for the session
 		/// @param[out] session The found session, or nullptr if no session matched the supplied parameters
-		bool get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination);
+		bool get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination) const;
 
 		/// @brief Gets an ETP session from the passed in source and destination and PGN combination
 		/// @param[in] source The source control function for the session
 		/// @param[in] destination The destination control function for the session
 		/// @param[in] parameterGroupNumber The PGN of the session
 		/// @param[out] session The found session, or nullptr if no session matched the supplied parameters
-		bool get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination, std::uint32_t parameterGroupNumber);
+		bool get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination, std::uint32_t parameterGroupNumber) const;
 
 		/// @brief Processes end of session callbacks
 		/// @param[in] session The session we've just completed
@@ -199,22 +199,22 @@ namespace isobus
 		/// @brief Sends the "end of message acknowledgement" message for the provided session
 		/// @param[in] session The session for which we're sending the EOM ACK
 		/// @returns true if the EOM was sent, false if sending was not successful
-		bool send_end_of_session_acknowledgement(ExtendedTransportProtocolSession *session); // ETP.CM_EOMA
+		bool send_end_of_session_acknowledgement(ExtendedTransportProtocolSession *session) const; // ETP.CM_EOMA
 
 		/// @brief Sends the "clear to send" message
 		/// @param[in] session The session for which we're sending the CTS
 		/// @returns true if the CTS was sent, false if sending was not successful
-		bool send_extended_connection_mode_clear_to_send(ExtendedTransportProtocolSession *session); // ETP.CM_CTS
+		bool send_extended_connection_mode_clear_to_send(ExtendedTransportProtocolSession *session) const; // ETP.CM_CTS
 
 		/// @brief Sends the "request to send" message as part of initiating a transmit
 		/// @param[in] session The session for which we're sending the RTS
 		/// @returns true if the RTS was sent, false if sending was not successful
-		bool send_extended_connection_mode_request_to_send(const ExtendedTransportProtocolSession *session); // ETP.CM_RTS
+		bool send_extended_connection_mode_request_to_send(const ExtendedTransportProtocolSession *session) const; // ETP.CM_RTS
 
 		/// @brief Sends the data packet offset message for the supplied session
 		/// @param[in] session The session for which we're sending the EDPO
 		/// @returns true if the EDPO was sent, false if sending was not successful
-		bool send_extended_connection_mode_data_packet_offset(const ExtendedTransportProtocolSession *session); // ETP.CM_DPO
+		bool send_extended_connection_mode_data_packet_offset(const ExtendedTransportProtocolSession *session) const; // ETP.CM_DPO
 
 		/// @brief Sets the state machine state of the ETP session
 		/// @param[in] session The session to update

--- a/isobus/include/isobus/isobus/can_managed_message.hpp
+++ b/isobus/include/isobus/isobus/can_managed_message.hpp
@@ -26,7 +26,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for the CANLibManagedMessage
 		/// @param[in] CANPort The can channel index the message uses
-		CANLibManagedMessage(std::uint8_t CANPort);
+		explicit CANLibManagedMessage(std::uint8_t CANPort);
 
 		/// @brief Sets the message data to the value supplied. Creates a copy.
 		/// @param[in] dataBuffer The data payload

--- a/isobus/include/isobus/isobus/can_message.hpp
+++ b/isobus/include/isobus/isobus/can_message.hpp
@@ -42,7 +42,7 @@ namespace isobus
 
 		/// @brief Constructor for a CAN message
 		/// @param[in] CANPort The can channel index the message uses
-		CANMessage(std::uint8_t CANPort);
+		explicit CANMessage(std::uint8_t CANPort);
 
 		/// @brief Destructor for a CAN message
 		virtual ~CANMessage() = default;

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -71,7 +71,7 @@ namespace isobus
 
 		/// @brief Returns the number of global PGN callbacks that have been registered with the network manager
 		/// @returns The number of global PGN callbacks that have been registered with the network manager
-		std::uint32_t get_number_global_parameter_group_number_callbacks() const;
+		std::size_t get_number_global_parameter_group_number_callbacks() const;
 
 		/// @brief Registers a callback for ANY control function sending the associated PGN
 		/// @param[in] parameterGroupNumber The PGN you want to register for
@@ -162,7 +162,7 @@ namespace isobus
 		                          std::uint8_t priority,
 		                          const void *data,
 		                          std::uint32_t size,
-		                          CANLibBadge<AddressClaimStateMachine>);
+		                          CANLibBadge<AddressClaimStateMachine>) const;
 
 		/// @brief Processes completed protocol messages. Causes PGN callbacks to trigger.
 		/// @param[in] protocolMessage The completed protocol message
@@ -205,7 +205,7 @@ namespace isobus
 		                                          std::uint32_t parameterGroupNumber,
 		                                          std::uint8_t priority,
 		                                          const void *data,
-		                                          std::uint32_t size);
+		                                          std::uint32_t size) const;
 
 		/// @brief Returns a control function based on a CAN address and channel index
 		/// @param[in] CANPort The CAN channel index of the CAN message being processed
@@ -252,7 +252,7 @@ namespace isobus
 		                          std::uint32_t parameterGroupNumber,
 		                          std::uint8_t priority,
 		                          const void *data,
-		                          std::uint32_t size);
+		                          std::uint32_t size) const;
 
 		/// @brief Gets a PGN callback for the global address by index
 		/// @param[in] index The index of the callback to get

--- a/isobus/include/isobus/isobus/can_partnered_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_partnered_control_function.hpp
@@ -41,6 +41,9 @@ namespace isobus
 		/// @param[in] NAMEFilters A list of filters that describe the identity of the CF based on NAME components
 		PartneredControlFunction(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters);
 
+		/// @brief Deleted copy constructor for PartneredControlFunction to avoid slicing
+		PartneredControlFunction(PartneredControlFunction &) = delete;
+
 		/// @brief The destructor for PartneredControlFunction
 		virtual ~PartneredControlFunction();
 

--- a/isobus/include/isobus/isobus/can_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_protocol.hpp
@@ -35,6 +35,9 @@ namespace isobus
 		/// @brief The base class constructor for a CANLibProtocol
 		CANLibProtocol();
 
+		/// @brief Deleted copy constructor for a CANLibProtocol
+		CANLibProtocol(CANLibProtocol &) = delete;
+
 		/// @brief The base class destructor for a CANLibProtocol
 		virtual ~CANLibProtocol();
 

--- a/isobus/include/isobus/isobus/can_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_transport_protocol.hpp
@@ -122,7 +122,7 @@ namespace isobus
 		TransportProtocolManager();
 
 		/// @brief The destructor for the TransportProtocolManager
-		virtual ~TransportProtocolManager();
+		~TransportProtocolManager() final;
 
 		/// @brief The protocol's initializer function
 		void initialize(CANLibBadge<CANNetworkManager>) override;
@@ -186,22 +186,22 @@ namespace isobus
 		/// @brief Sends the "broadcast announce" message
 		/// @param[in] session The session for which we're sending the BAM
 		/// @returns true if the BAM was sent, false if sending was not successful
-		bool send_broadcast_announce_message(TransportProtocolSession *session);
+		bool send_broadcast_announce_message(TransportProtocolSession *session) const;
 
 		/// @brief Sends the "clear to send" message
 		/// @param[in] session The session for which we're sending the CTS
 		/// @returns true if the CTS was sent, false if sending was not successful
-		bool send_clear_to_send(TransportProtocolSession *session);
+		bool send_clear_to_send(TransportProtocolSession *session) const;
 
 		/// @brief Sends the "request to send" message as part of initiating a transmit
 		/// @param[in] session The session for which we're sending the RTS
 		/// @returns true if the RTS was sent, false if sending was not successful
-		bool send_request_to_send(TransportProtocolSession *session);
+		bool send_request_to_send(TransportProtocolSession *session) const;
 
 		/// @brief Sends the "end of message acknowledgement" message for the provided session
 		/// @param[in] session The session for which we're sending the EOM ACK
 		/// @returns true if the EOM was sent, false if sending was not successful
-		bool send_end_of_session_acknowledgement(TransportProtocolSession *session);
+		bool send_end_of_session_acknowledgement(TransportProtocolSession *session) const;
 
 		/// @brief Sets the state machine state of the TP session
 		/// @param[in] session The session to update

--- a/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
@@ -40,6 +40,7 @@
 #include "isobus/isobus/can_protocol.hpp"
 #include "isobus/utility/processing_flags.hpp"
 
+#include <array>
 #include <list>
 #include <memory>
 #include <string>
@@ -174,8 +175,7 @@ namespace isobus
 		{
 		public:
 			/// @brief Constructor for a DTC, sets default values at construction time
-			/// @param[in] internalControlFunction The internal control function to use for sending messages
-			DiagnosticTroubleCode();
+			DiagnosticTroubleCode() = default;
 
 			/// @brief Constructor for a DTC, sets all values explicitly
 			/// @param[in] spn The suspect parameter number
@@ -191,12 +191,12 @@ namespace isobus
 			///  @brief Returns the occurance count, which will be kept track of by the protocol
 			std::uint8_t get_occurrance_count() const;
 
-			std::uint32_t suspectParameterNumber; ///< This 19-bit number is used to identify the item for which diagnostics are being reported
-			std::uint8_t failureModeIdentifier; ///< The FMI defines the type of failure detected in the sub-system identified by an SPN
-			LampStatus lampState; ///< The J1939 lamp state for this DTC
+			std::uint32_t suspectParameterNumber = 0xFFFFFFFF; ///< This 19-bit number is used to identify the item for which diagnostics are being reported
+			std::uint8_t failureModeIdentifier = static_cast<std::uint8_t>(FailureModeIdentifier::ConditionExists); ///< The FMI defines the type of failure detected in the sub-system identified by an SPN
+			LampStatus lampState = LampStatus::None; ///< The J1939 lamp state for this DTC
 		private:
 			friend class DiagnosticProtocol; ///< Allow the protocol to have write access the occurance but require other to use getter only
-			std::uint8_t occuranceCount; ///< Number of times the DTC has been active (0 to 126 with 127 being not available)
+			std::uint8_t occuranceCount = 0; ///< Number of times the DTC has been active (0 to 126 with 127 being not available)
 		};
 
 		/// @brief Used to tell the CAN stack that diagnostic messages should be sent from the specified internal control function
@@ -383,17 +383,17 @@ namespace isobus
 		static constexpr std::uint8_t DM13_BITS_PER_NETWORK = 2; ///< Number of bits for the network SPNs
 
 		/// @brief Lists the J1939 networks by index rather than by definition in J1939-73 5.7.13
-		static constexpr Network J1939NetworkIndicies[DM13_NUMBER_OF_J1939_NETWORKS] = { Network::SAEJ1939Network1PrimaryVehicleNetwork,
-			                                                                               Network::SAEJ1939Network2,
-			                                                                               Network::SAEJ1939Network3,
-			                                                                               Network::SAEJ1939Network4,
-			                                                                               Network::SAEJ1939Network5,
-			                                                                               Network::SAEJ1939Network6,
-			                                                                               Network::SAEJ1939Network7,
-			                                                                               Network::SAEJ1939Network8,
-			                                                                               Network::SAEJ1939Network9,
-			                                                                               Network::SAEJ1939Network10,
-			                                                                               Network::SAEJ1939Network11 };
+		static constexpr std::array<Network, DM13_NUMBER_OF_J1939_NETWORKS> J1939NetworkIndicies = { Network::SAEJ1939Network1PrimaryVehicleNetwork,
+			                                                                                           Network::SAEJ1939Network2,
+			                                                                                           Network::SAEJ1939Network3,
+			                                                                                           Network::SAEJ1939Network4,
+			                                                                                           Network::SAEJ1939Network5,
+			                                                                                           Network::SAEJ1939Network6,
+			                                                                                           Network::SAEJ1939Network7,
+			                                                                                           Network::SAEJ1939Network8,
+			                                                                                           Network::SAEJ1939Network9,
+			                                                                                           Network::SAEJ1939Network10,
+			                                                                                           Network::SAEJ1939Network11 };
 
 		/// @brief The constructor for this protocol
 		explicit DiagnosticProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction);

--- a/isobus/include/isobus/isobus/isobus_language_command_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_language_command_interface.hpp
@@ -147,6 +147,9 @@ namespace isobus
 		/// @param filteredControlFunction The control function you want to explicitly communicate with
 		LanguageCommandInterface(std::shared_ptr<InternalControlFunction> sourceControlFunction, std::shared_ptr<PartneredControlFunction> filteredControlFunction);
 
+		/// @brief Deleted copy constructor for LanguageCommandInterface
+		LanguageCommandInterface(LanguageCommandInterface &) = delete;
+
 		/// @brief Destructor for the LanguageCommandInterface
 		~LanguageCommandInterface();
 

--- a/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
@@ -84,16 +84,16 @@ namespace isobus
 		};
 
 		/// @brief A callback for handling a value request command from the TC
-		typedef bool (*RequestValueCommandCallback)(std::uint16_t elementNumber,
-		                                            std::uint16_t DDI,
-		                                            std::uint32_t &processVariableValue,
-		                                            void *parentPointer);
+		using RequestValueCommandCallback = bool (*)(std::uint16_t elementNumber,
+		                                             std::uint16_t DDI,
+		                                             std::uint32_t &processVariableValue,
+		                                             void *parentPointer);
 
 		/// @brief A callback for handling a set value command from the TC
-		typedef bool (*ValueCommandCallback)(std::uint16_t elementNumber,
-		                                     std::uint16_t DDI,
-		                                     std::uint32_t processVariableValue,
-		                                     void *parentPointer);
+		using ValueCommandCallback = bool (*)(std::uint16_t elementNumber,
+		                                      std::uint16_t DDI,
+		                                      std::uint32_t processVariableValue,
+		                                      void *parentPointer);
 
 		/// @brief The constructor for a TaskControllerClient
 		/// @param[in] partner The TC server control function

--- a/isobus/include/isobus/isobus/isobus_task_controller_client_objects.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client_objects.hpp
@@ -37,6 +37,9 @@ namespace isobus
 			/// @param[in] uniqueID The object ID of the object. Must be unique in the DDOP.
 			Object(std::string objectDesignator, std::uint16_t uniqueID);
 
+			/// @brief Destructor for a TC Object
+			virtual ~Object() = default;
+
 			/// @brief Returns the Descriptive text for this object, UTF-8 encoded, 32 characters max
 			/// @returns Descriptive text for this object, UTF-8 encoded, 32 characters max
 			std::string get_designator() const;
@@ -98,7 +101,7 @@ namespace isobus
 			             bool shouldUseExtendedStructureLabel);
 
 			/// @brief Destructor for a DeviceObject
-			virtual ~DeviceObject() = default;
+			~DeviceObject() override = default;
 
 			/// @brief Returns the XML namespace for the object
 			/// @returns the XML namespace for the object
@@ -191,7 +194,7 @@ namespace isobus
 			                    std::uint16_t uniqueID);
 
 			/// @brief Destructor for a DeviceElementObject
-			virtual ~DeviceElementObject() = default;
+			~DeviceElementObject() override = default;
 
 			/// @brief Returns the XML namespace for the object
 			/// @returns The string "DET", the XML namespace for the DeviceElementObject
@@ -277,7 +280,7 @@ namespace isobus
 			                        std::uint16_t uniqueID);
 
 			/// @brief Destructor for a DeviceProcessDataObject
-			virtual ~DeviceProcessDataObject() = default;
+			~DeviceProcessDataObject() override = default;
 
 			/// @brief Returns the XML element namespace for DeviceProcess-Data.
 			/// @returns The string "DPD", the XML element namespace for DeviceProcess-Data.
@@ -334,7 +337,7 @@ namespace isobus
 			                     std::uint16_t uniqueID);
 
 			/// @brief Destructor for a DevicePropertyObject
-			virtual ~DevicePropertyObject() = default;
+			~DevicePropertyObject() override = default;
 
 			/// @brief Returns the XML element namespace for DeviceProperty.
 			/// @returns The string "DPD", the XML element namespace for DeviceProcessData.
@@ -391,7 +394,7 @@ namespace isobus
 			                              std::uint16_t uniqueID);
 
 			/// @brief Destructor for a DeviceValuePresentationObject
-			virtual ~DeviceValuePresentationObject() = default;
+			~DeviceValuePresentationObject() override = default;
 
 			/// @brief Returns the XML element namespace for DeviceValuePresentation.
 			/// @returns The string "DPD", the XML element namespace for DeviceProcessData.

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -266,6 +266,9 @@ namespace isobus
 		/// @param[in] clientSource The internal control function to communicate from
 		VirtualTerminalClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource);
 
+		/// @brief Deleted copy constructor for VirtualTerminalClient
+		VirtualTerminalClient(VirtualTerminalClient &) = delete;
+
 		/// @brief The destructor for the VirtualTerminalClient
 		~VirtualTerminalClient();
 

--- a/isobus/src/can_address_claim_state_machine.cpp
+++ b/isobus/src/can_address_claim_state_machine.cpp
@@ -7,7 +7,6 @@
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
 #include "isobus/isobus/can_address_claim_state_machine.hpp"
-#include "isobus/isobus/can_constants.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/utility/system_timing.hpp"
@@ -20,12 +19,8 @@ namespace isobus
 {
 	AddressClaimStateMachine::AddressClaimStateMachine(std::uint8_t preferredAddressValue, NAME ControlFunctionNAME, std::uint8_t portIndex) :
 	  m_isoname(ControlFunctionNAME),
-	  m_currentState(State::None),
-	  m_timestamp_ms(0),
 	  m_portIndex(portIndex),
-	  m_preferredAddress(preferredAddressValue),
-	  m_claimedAddress(NULL_CAN_ADDRESS),
-	  m_enabled(true)
+	  m_preferredAddress(preferredAddressValue)
 	{
 		assert(m_preferredAddress != BROADCAST_CAN_ADDRESS);
 		assert(m_preferredAddress != NULL_CAN_ADDRESS);
@@ -183,13 +178,11 @@ namespace isobus
 
 				case State::ContendForPreferredAddress:
 				{
-					// TODO
+					/// @todo Non-arbitratable address contention (there is not a good reason to use this, but we should add support anyways)
 				}
 				break;
 
 				default:
-				case State::AddressClaimingComplete:
-				case State::UnableToClaim:
 				{
 				}
 				break;
@@ -270,14 +263,14 @@ namespace isobus
 		m_currentState = value;
 	}
 
-	bool AddressClaimStateMachine::send_request_to_claim()
+	bool AddressClaimStateMachine::send_request_to_claim() const
 	{
 		bool retVal = false;
 
 		if (get_enabled())
 		{
 			const std::uint8_t addressClaimRequestLength = 3;
-			const std::uint32_t PGN = static_cast<std::uint32_t>(CANLibParameterGroupNumber::AddressClaim);
+			const auto PGN = static_cast<std::uint32_t>(CANLibParameterGroupNumber::AddressClaim);
 			std::uint8_t dataBuffer[addressClaimRequestLength];
 
 			dataBuffer[0] = (PGN & std::numeric_limits<std::uint8_t>::max());

--- a/isobus/src/can_callbacks.cpp
+++ b/isobus/src/can_callbacks.cpp
@@ -24,7 +24,7 @@ namespace isobus
 		mParent = oldObj.mParent;
 	}
 
-	bool ParameterGroupNumberCallbackData::operator==(const ParameterGroupNumberCallbackData &obj)
+	bool ParameterGroupNumberCallbackData::operator==(const ParameterGroupNumberCallbackData &obj) const
 	{
 		return ((obj.mCallback == this->mCallback) &&
 		        (obj.mParameterGroupNumber == this->mParameterGroupNumber) &&

--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -463,7 +463,7 @@ namespace isobus
 		}
 	}
 
-	bool ExtendedTransportProtocolManager::get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination)
+	bool ExtendedTransportProtocolManager::get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination) const
 	{
 		session = nullptr;
 
@@ -479,7 +479,7 @@ namespace isobus
 		return (nullptr != session);
 	}
 
-	bool ExtendedTransportProtocolManager::get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination, std::uint32_t parameterGroupNumber)
+	bool ExtendedTransportProtocolManager::get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination, std::uint32_t parameterGroupNumber) const
 	{
 		bool retVal = false;
 		session = nullptr;
@@ -508,7 +508,7 @@ namespace isobus
 		}
 	}
 
-	bool ExtendedTransportProtocolManager::send_end_of_session_acknowledgement(ExtendedTransportProtocolSession *session)
+	bool ExtendedTransportProtocolManager::send_end_of_session_acknowledgement(ExtendedTransportProtocolSession *session) const
 	{
 		bool retVal = false;
 
@@ -533,7 +533,7 @@ namespace isobus
 		return retVal;
 	}
 
-	bool ExtendedTransportProtocolManager::send_extended_connection_mode_clear_to_send(ExtendedTransportProtocolSession *session)
+	bool ExtendedTransportProtocolManager::send_extended_connection_mode_clear_to_send(ExtendedTransportProtocolSession *session) const
 	{
 		bool retVal = false;
 
@@ -569,7 +569,7 @@ namespace isobus
 		return retVal;
 	}
 
-	bool ExtendedTransportProtocolManager::send_extended_connection_mode_request_to_send(const ExtendedTransportProtocolSession *session)
+	bool ExtendedTransportProtocolManager::send_extended_connection_mode_request_to_send(const ExtendedTransportProtocolSession *session) const
 	{
 		bool retVal = false;
 
@@ -593,7 +593,7 @@ namespace isobus
 		return retVal;
 	}
 
-	bool ExtendedTransportProtocolManager::send_extended_connection_mode_data_packet_offset(const ExtendedTransportProtocolSession *session)
+	bool ExtendedTransportProtocolManager::send_extended_connection_mode_data_packet_offset(const ExtendedTransportProtocolSession *session) const
 	{
 		bool retVal = false;
 
@@ -804,9 +804,9 @@ namespace isobus
 				}
 				break;
 
-				case StateMachineState::None:
 				default:
 				{
+					// Nothing to do.
 				}
 				break;
 			}

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -40,7 +40,7 @@ namespace isobus
 	InternalControlFunction::~InternalControlFunction()
 	{
 		const std::lock_guard<std::mutex> lock(ControlFunction::controlFunctionProcessingMutex);
-		if (0 != internalControlFunctionList.size())
+		if (!internalControlFunctionList.empty())
 		{
 			auto thisObject = std::find(internalControlFunctionList.begin(), internalControlFunctionList.end(), this);
 

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -49,7 +49,7 @@ namespace isobus
 
 	void CANNetworkManager::add_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
-		globalParameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent));
+		globalParameterGroupNumberCallbacks.emplace_back(parameterGroupNumber, callback, parent);
 	}
 
 	void CANNetworkManager::remove_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
@@ -62,7 +62,7 @@ namespace isobus
 		}
 	}
 
-	std::uint32_t CANNetworkManager::get_number_global_parameter_group_number_callbacks() const
+	std::size_t CANNetworkManager::get_number_global_parameter_group_number_callbacks() const
 	{
 		return globalParameterGroupNumberCallbacks.size();
 	}
@@ -70,7 +70,7 @@ namespace isobus
 	void CANNetworkManager::add_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
 		std::lock_guard<std::mutex> lock(anyControlFunctionCallbacksMutex);
-		anyControlFunctionParameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent));
+		anyControlFunctionParameterGroupNumberCallbacks.emplace_back(parameterGroupNumber, callback, parent);
 	}
 
 	void CANNetworkManager::remove_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
@@ -234,7 +234,7 @@ namespace isobus
 	                                             std::uint8_t priority,
 	                                             const void *data,
 	                                             std::uint32_t size,
-	                                             CANLibBadge<AddressClaimStateMachine>)
+	                                             CANLibBadge<AddressClaimStateMachine>) const
 	{
 		return send_can_message_raw(portIndex, sourceAddress, destAddress, parameterGroupNumber, priority, data, size);
 	}
@@ -580,7 +580,7 @@ namespace isobus
 	                                                             std::uint32_t parameterGroupNumber,
 	                                                             std::uint8_t priority,
 	                                                             const void *data,
-	                                                             std::uint32_t size)
+	                                                             std::uint32_t size) const
 	{
 		HardwareInterfaceCANFrame txFrame;
 		txFrame.identifier = DEFAULT_IDENTIFIER;
@@ -756,7 +756,7 @@ namespace isobus
 		}
 	}
 
-	bool CANNetworkManager::send_can_message_raw(std::uint32_t portIndex, std::uint8_t sourceAddress, std::uint8_t destAddress, std::uint32_t parameterGroupNumber, std::uint8_t priority, const void *data, std::uint32_t size)
+	bool CANNetworkManager::send_can_message_raw(std::uint32_t portIndex, std::uint8_t sourceAddress, std::uint8_t destAddress, std::uint32_t parameterGroupNumber, std::uint8_t priority, const void *data, std::uint32_t size) const
 	{
 		HardwareInterfaceCANFrame tempFrame = construct_frame(portIndex, sourceAddress, destAddress, parameterGroupNumber, priority, data, size);
 		bool retVal = false;

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -507,7 +507,7 @@ namespace isobus
 		}
 	}
 
-	bool TransportProtocolManager::send_broadcast_announce_message(TransportProtocolSession *session)
+	bool TransportProtocolManager::send_broadcast_announce_message(TransportProtocolSession *session) const
 	{
 		bool retVal = false;
 
@@ -531,7 +531,7 @@ namespace isobus
 		return retVal;
 	}
 
-	bool TransportProtocolManager::send_clear_to_send(TransportProtocolSession *session)
+	bool TransportProtocolManager::send_clear_to_send(TransportProtocolSession *session) const
 	{
 		bool retVal = false;
 
@@ -567,7 +567,7 @@ namespace isobus
 		return retVal;
 	}
 
-	bool TransportProtocolManager::send_request_to_send(TransportProtocolSession *session)
+	bool TransportProtocolManager::send_request_to_send(TransportProtocolSession *session) const
 	{
 		bool retVal = false;
 
@@ -591,7 +591,7 @@ namespace isobus
 		return retVal;
 	}
 
-	bool TransportProtocolManager::send_end_of_session_acknowledgement(TransportProtocolSession *session)
+	bool TransportProtocolManager::send_end_of_session_acknowledgement(TransportProtocolSession *session) const
 	{
 		bool retVal = false;
 

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -46,14 +46,7 @@
 namespace isobus
 {
 	std::list<DiagnosticProtocol *> DiagnosticProtocol::diagnosticProtocolList;
-	constexpr DiagnosticProtocol::Network DiagnosticProtocol::J1939NetworkIndicies[DM13_NUMBER_OF_J1939_NETWORKS];
-
-	DiagnosticProtocol::DiagnosticTroubleCode::DiagnosticTroubleCode() :
-	  suspectParameterNumber(0xFFFFFFFF),
-	  failureModeIdentifier(static_cast<std::uint8_t>(FailureModeIdentifier::ConditionExists)),
-	  lampState(LampStatus::None)
-	{
-	}
+	constexpr std::array<DiagnosticProtocol::Network, DiagnosticProtocol::DM13_NUMBER_OF_J1939_NETWORKS> DiagnosticProtocol::J1939NetworkIndicies;
 
 	DiagnosticProtocol::DiagnosticTroubleCode::DiagnosticTroubleCode(std::uint32_t spn, FailureModeIdentifier fmi, LampStatus lamp) :
 	  suspectParameterNumber(spn),

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -3572,7 +3572,7 @@ namespace isobus
 								{
 									AssignedAuxiliaryInputDevice inputDevice{ message->get_source_control_function()->get_NAME().get_full_name(), modelIdentificationCode, {} };
 									parentVT->assignedAuxiliaryInputDevices.push_back(inputDevice);
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[AUX-N]: New auxiliary input device with name: " + isobus::to_string(inputDevice.name) + " and model identification code: " + std::to_string(modelIdentificationCode));
+									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[AUX-N]: New auxiliary input device with name: " + isobus::to_string(inputDevice.name) + " and model identification code: " + isobus::to_string(modelIdentificationCode));
 								}
 							}
 						}


### PR DESCRIPTION
* Standardized all instances of `std::to_string` to `isobus::to_string`
* Fixed missing header files in CMake
* Fixed a number of trivial code smells from Sonar