### PR TITLE
[Core]: Update hardware interface to use event dispatching system

### DIFF
--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -18,11 +18,6 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *)
-{
-	isobus::CANNetworkManager::CANNetwork.update();
-}
-
 int main()
 {
 	std::signal(SIGINT, signal_handler);

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -23,11 +23,6 @@ void update_CAN_network(void *)
 	isobus::CANNetworkManager::CANNetwork.update();
 }
 
-void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
-{
-	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
-}
-
 int main()
 {
 	std::signal(SIGINT, signal_handler);
@@ -57,9 +52,6 @@ int main()
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
-
-	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 

--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -45,11 +45,6 @@ void update_CAN_network(void *)
 	isobus::CANNetworkManager::CANNetwork.update();
 }
 
-void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
-{
-	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
-}
-
 int main()
 {
 	std::signal(SIGINT, signal_handler);
@@ -79,9 +74,6 @@ int main()
 		std::cout << "Failed to start hardware interface. A CAN driver might be invalid." << std::endl;
 		return -2;
 	}
-	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
-
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 
 	isobus::NAME TestDeviceNAME(0);

--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -40,11 +40,6 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *)
-{
-	isobus::CANNetworkManager::CANNetwork.update();
-}
-
 int main()
 {
 	std::signal(SIGINT, signal_handler);

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -21,11 +21,6 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *)
-{
-	isobus::CANNetworkManager::CANNetwork.update();
-}
-
 bool example_proprietary_a_pgn_request_handler(std::uint32_t parameterGroupNumber,
                                                isobus::ControlFunction *,
                                                bool &acknowledge,

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -26,11 +26,6 @@ void update_CAN_network(void *)
 	isobus::CANNetworkManager::CANNetwork.update();
 }
 
-void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
-{
-	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
-}
-
 bool example_proprietary_a_pgn_request_handler(std::uint32_t parameterGroupNumber,
                                                isobus::ControlFunction *,
                                                bool &acknowledge,
@@ -118,9 +113,6 @@ int main()
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid" << std::endl;
 		return -2;
 	}
-
-	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 

--- a/examples/task_controller_client/main.cpp
+++ b/examples/task_controller_client/main.cpp
@@ -26,16 +26,6 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *)
-{
-	isobus::CANNetworkManager::CANNetwork.update();
-}
-
-void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
-{
-	isobus::CANNetworkManager::can_lib_process_rx_message(rawFrame, parentPointer);
-}
-
 int main()
 {
 	std::signal(SIGINT, signal_handler);
@@ -67,9 +57,6 @@ int main()
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
-
-	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -27,11 +27,6 @@ void update_CAN_network(void *)
 	isobus::CANNetworkManager::CANNetwork.update();
 }
 
-void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
-{
-	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
-}
-
 int main()
 {
 	std::signal(SIGINT, signal_handler);
@@ -61,9 +56,6 @@ int main()
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
-
-	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -22,11 +22,6 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *)
-{
-	isobus::CANNetworkManager::CANNetwork.update();
-}
-
 int main()
 {
 	std::signal(SIGINT, signal_handler);

--- a/examples/virtual_terminal/aux_functions/main.cpp
+++ b/examples/virtual_terminal/aux_functions/main.cpp
@@ -24,16 +24,6 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *)
-{
-	isobus::CANNetworkManager::CANNetwork.update();
-}
-
-void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
-{
-	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
-}
-
 // This callback will provide us with event driven notifications of auxiliary input from the stack
 void handle_aux_function_input(const isobus::VirtualTerminalClient::AuxiliaryFunctionEvent &event)
 {
@@ -71,9 +61,6 @@ int main()
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
-
-	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 

--- a/examples/virtual_terminal/version3_object_pool/main.cpp
+++ b/examples/virtual_terminal/version3_object_pool/main.cpp
@@ -30,11 +30,6 @@ void update_CAN_network(void *)
 	isobus::CANNetworkManager::CANNetwork.update();
 }
 
-void raw_can_glue(isobus::HardwareInterfaceCANFrame &rawFrame, void *parentPointer)
-{
-	isobus::CANNetworkManager::CANNetwork.can_lib_process_rx_message(rawFrame, parentPointer);
-}
-
 // This callback will provide us with event driven notifications of button presses from the stack
 void handleVTKeyEvents(const isobus::VirtualTerminalClient::VTKeyEvent &event)
 {
@@ -111,9 +106,6 @@ int main()
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
-
-	CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-	CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 

--- a/examples/virtual_terminal/version3_object_pool/main.cpp
+++ b/examples/virtual_terminal/version3_object_pool/main.cpp
@@ -25,11 +25,6 @@ void signal_handler(int)
 	running = false;
 }
 
-void update_CAN_network(void *)
-{
-	isobus::CANNetworkManager::CANNetwork.update();
-}
-
 // This callback will provide us with event driven notifications of button presses from the stack
 void handleVTKeyEvents(const isobus::VirtualTerminalClient::VTKeyEvent &event)
 {

--- a/hardware_integration/README.md
+++ b/hardware_integration/README.md
@@ -20,7 +20,7 @@ Let's discuss how these components work. Then, we'll go over how you can write y
 The CAN stack relies on a couple of functions being defined externally to function. This boundary keeps the core stack completely isolated from the hardware layer. Thus, the content of the `isobus` folder can function entirely on its own if that meets your needs better than using the built in hardware interface layer.
 These functions are:
 
-* `bool send_can_message_to_hardware(HardwareInterfaceCANFrame frame);`
+* `bool send_can_message_frame_to_hardware(const HardwareInterfaceCANFrame &frame);`
 	- This is how the CAN stack will send a frame to the actual hardware.
 	- This is already defined in `CANHardwareInterface` and wraps the actual CAN driver calls.
 	- `CANHardwareInterface` Stores these frames in a queue that will be fed to your underlying CAN driver.

--- a/isobus/include/isobus/isobus/can_hardware_abstraction.hpp
+++ b/isobus/include/isobus/isobus/can_hardware_abstraction.hpp
@@ -7,8 +7,8 @@
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
 
-#ifndef CAN_HARDWARE_ABSTRACTION
-#define CAN_HARDWARE_ABSTRACTION
+#ifndef CAN_HARDWARE_ABSTRACTION_HPP
+#define CAN_HARDWARE_ABSTRACTION_HPP
 
 #include "isobus/isobus/can_frame.hpp"
 
@@ -16,10 +16,17 @@
 
 namespace isobus
 {
-	/// @brief The abstraction layer between the hardware and the stack
+	/// @brief The sending abstraction layer between the hardware and the stack
 	/// @param[in] frame The frame to transmit from the hardware
-	bool send_can_message_to_hardware(HardwareInterfaceCANFrame frame);
+	bool send_can_message_frame_to_hardware(const HardwareInterfaceCANFrame &frame);
+
+	/// @brief The receiving abstraction layer between the hardware and the stack
+	/// @param[in] frame The frame to receive from the hardware
+	void receive_can_message_frame_from_hardware(const HardwareInterfaceCANFrame &frame);
+
+	/// @brief The periodic update abstraction layer between the hardware and the stack
+	void periodic_update_from_hardware();
 
 } // namespace isobus
 
-#endif // CAN_HARDWARE_ABSTRACTION
+#endif // CAN_HARDWARE_ABSTRACTION_HPP

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -8,8 +8,8 @@
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
 
-#ifndef CAN_NETWORK_MANAGER
-#define CAN_NETWORK_MANAGER
+#ifndef CAN_NETWORK_MANAGER_HPP
+#define CAN_NETWORK_MANAGER_HPP
 
 #include "isobus/isobus/can_address_claim_state_machine.hpp"
 #include "isobus/isobus/can_badge.hpp"
@@ -115,8 +115,7 @@ namespace isobus
 
 		/// @brief Process the CAN Rx queue
 		/// @param[in] rxFrame Frame to process
-		/// @param[in] parentClass A generic context variable
-		static void can_lib_process_rx_message(HardwareInterfaceCANFrame &rxFrame, void *parentClass);
+		static void process_receive_can_message_frame(const HardwareInterfaceCANFrame &rxFrame);
 
 		/// @brief Informs the network manager that a partner was deleted so that it can be purged from the address/cf tables
 		/// @param[in] partner Pointer to the partner being deleted
@@ -185,7 +184,7 @@ namespace isobus
 
 		/// @brief Creates new control function classes based on the frames coming in from the bus
 		/// @param[in] rxFrame Raw frames coming in from the bus
-		void update_control_functions(HardwareInterfaceCANFrame &rxFrame);
+		void update_control_functions(const HardwareInterfaceCANFrame &rxFrame);
 
 		/// @brief Checks if new partners have been created and matches them to existing control functions
 		void update_new_partners();
@@ -278,4 +277,4 @@ namespace isobus
 
 } // namespace isobus
 
-#endif // CAN_NETWORK_MANAGER
+#endif // CAN_NETWORK_MANAGER_HPP

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -250,12 +250,12 @@ namespace isobus
 		return retVal;
 	}
 
-	void isobus::receive_can_message_frame_from_hardware(const HardwareInterfaceCANFrame &rxFrame)
+	void receive_can_message_frame_from_hardware(const HardwareInterfaceCANFrame &rxFrame)
 	{
 		CANNetworkManager::process_receive_can_message_frame(rxFrame);
 	}
 
-	void isobus::periodic_update_from_hardware()
+	void periodic_update_from_hardware()
 	{
 		CANNetworkManager::CANNetwork.update();
 	}

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -250,7 +250,17 @@ namespace isobus
 		return retVal;
 	}
 
-	void CANNetworkManager::can_lib_process_rx_message(HardwareInterfaceCANFrame &rxFrame, void *)
+	void isobus::receive_can_message_frame_from_hardware(const HardwareInterfaceCANFrame &rxFrame)
+	{
+		CANNetworkManager::process_receive_can_message_frame(rxFrame);
+	}
+
+	void isobus::periodic_update_from_hardware()
+	{
+		CANNetworkManager::CANNetwork.update();
+	}
+
+	void CANNetworkManager::process_receive_can_message_frame(const HardwareInterfaceCANFrame &rxFrame)
 	{
 		CANLibManagedMessage tempCANMessage(rxFrame.channel);
 
@@ -428,7 +438,7 @@ namespace isobus
 		}
 	}
 
-	void CANNetworkManager::update_control_functions(HardwareInterfaceCANFrame &rxFrame)
+	void CANNetworkManager::update_control_functions(const HardwareInterfaceCANFrame &rxFrame)
 	{
 		if ((static_cast<std::uint32_t>(CANLibParameterGroupNumber::AddressClaim) == CANIdentifier(rxFrame.identifier).get_parameter_group_number()) &&
 		    (CAN_DATA_LENGTH == rxFrame.dataLength) &&
@@ -764,7 +774,7 @@ namespace isobus
 		if ((DEFAULT_IDENTIFIER != tempFrame.identifier) &&
 		    (portIndex < CAN_PORT_MAXIMUM))
 		{
-			retVal = send_can_message_to_hardware(tempFrame);
+			retVal = send_can_message_frame_to_hardware(tempFrame);
 		}
 		return retVal;
 	}

--- a/test/address_claim_tests.cpp
+++ b/test/address_claim_tests.cpp
@@ -22,17 +22,6 @@ TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 	CANHardwareInterface::assign_can_channel_frame_handler(1, secondDevice);
 	CANHardwareInterface::start();
 
-	CANHardwareInterface::add_can_lib_update_callback(
-	  [](void *) {
-		  CANNetworkManager::CANNetwork.update();
-	  },
-	  nullptr);
-	CANHardwareInterface::add_raw_can_message_rx_callback(
-	  [](HardwareInterfaceCANFrame &rxFrame, void *parentPointer) {
-		  CANNetworkManager::CANNetwork.can_lib_process_rx_message(rxFrame, parentPointer);
-	  },
-	  nullptr);
-
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 
 	NAME firstName(0);

--- a/test/hardware_interface_tests.cpp
+++ b/test/hardware_interface_tests.cpp
@@ -135,7 +135,8 @@ TEST(HARDWARE_INTERFACE_TESTS, PeriodicUpdateEventListener)
 
 TEST(HARDWARE_INTERFACE_TESTS, AddRemoveHardwareFrameHandler)
 {
-	EXPECT_TRUE(false);
+	//! @todo Implement this test
+	// We probably want CANNetworkManager to not use the singleton pattern first
 }
 
 TEST(HARDWARE_INTERFACE_TESTS, PeriodicUpdateIntervalSetting)

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -102,11 +102,6 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::add_can_lib_update_callback(
-	  [](void *) {
-		  CANNetworkManager::CANNetwork.update();
-	  },
-	  nullptr);
 	CANHardwareInterface::start();
 
 	NAME clientNAME(0);
@@ -145,7 +140,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 	testFrame.data[5] = 0x82;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0xA0;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 
 	DerivedTestTCClient interfaceUnderTest(vtPartner, internalECU);
 
@@ -353,11 +348,6 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::add_can_lib_update_callback(
-	  [](void *) {
-		  CANNetworkManager::CANNetwork.update();
-	  },
-	  nullptr);
 	CANHardwareInterface::start();
 
 	NAME clientNAME(0);
@@ -397,7 +387,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x82;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0xA0;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 
 	DerivedTestTCClient interfaceUnderTest(tcPartner, internalECU);
 	interfaceUnderTest.initialize(false);
@@ -432,8 +422,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x00; // Command address
 	testFrame.data[6] = 0x00; // Command
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
-
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendWorkingSetMaster);
@@ -459,7 +448,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0b00000100;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::ProcessDDOP);
@@ -481,7 +470,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x01; // Number of booms for section control (1)
 	testFrame.data[6] = 0x20; // Number of sections for section control (32)
 	testFrame.data[7] = 0x10; // Number channels for position based control (16)
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 
 	CANNetworkManager::CANNetwork.update();
 
@@ -518,7 +507,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x00; // PGN
 	testFrame.data[6] = 0xCB; // PGN
 	testFrame.data[7] = 0x00; // PGN
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::Disconnected);
 
@@ -549,7 +538,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF; // Reserved
 	testFrame.data[6] = 0xFF; // Reserved
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendRequestTransferObjectPool);
 
@@ -587,7 +576,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF; // Reserved
 	testFrame.data[6] = 0xFF; // Reserved
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendRequestVersionResponse);
 	// Test strange technical command doesn't change the state
@@ -603,7 +592,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF; // Reserved
 	testFrame.data[6] = 0xFF; // Reserved
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::WaitForRequestVersionFromServer);
 
@@ -620,7 +609,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF; // No Label
 	testFrame.data[6] = 0xFF; // No Label
 	testFrame.data[7] = 0xFF; // No Label
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendRequestTransferObjectPool);
 
@@ -652,7 +641,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendDeleteObjectPool);
 
@@ -669,7 +658,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = '.';
 	testFrame.data[6] = '0';
 	testFrame.data[7] = ' ';
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::RequestLocalizationLabel);
 
@@ -688,7 +677,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendRequestTransferObjectPool);
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::WaitForLocalizationLabelResponse);
@@ -705,7 +694,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendDeleteObjectPool);
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::WaitForLocalizationLabelResponse);
@@ -722,7 +711,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendObjectPoolActivate);
 
@@ -757,7 +746,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendObjectPoolActivate);
 
@@ -767,7 +756,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.identifier = 0x18CB83F7;
 	testFrame.data[0] = 0x71; // Mux
 	testFrame.data[1] = 0x01; // Ran out of memory!
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_NE(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendObjectPoolActivate);
 	interfaceUnderTest.initialize(false); // Fix the interface after terminate was called
@@ -779,7 +768,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.identifier = 0x18CB83F7;
 	testFrame.data[0] = 0x51; // Mux
 	testFrame.data[1] = 0x00;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::BeginTransferDDOP);
 
@@ -789,7 +778,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.identifier = 0x18CB83F7;
 	testFrame.data[0] = 0x51; // Mux
 	testFrame.data[1] = 0x01; // Not enough memory!
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_NE(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::BeginTransferDDOP);
 	interfaceUnderTest.initialize(false); // Fix the interface after terminate was called
@@ -848,7 +837,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::Connected);
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::WaitForObjectPoolActivateResponse);
@@ -864,7 +853,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_NE(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::Connected);
 
@@ -1162,11 +1151,6 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::add_can_lib_update_callback(
-	  [](void *) {
-		  CANNetworkManager::CANNetwork.update();
-	  },
-	  nullptr);
 	CANHardwareInterface::start();
 
 	NAME clientNAME(0);
@@ -1203,7 +1187,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 		std::this_thread::sleep_for(std::chrono::milliseconds(50));
 	}
 
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 
 	DerivedTestTCClient interfaceUnderTest(TestPartnerTC, internalECU);
 	interfaceUnderTest.initialize(false);
@@ -1235,7 +1219,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00; // Command address
 	testFrame.data[6] = 0x00; // Command
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 
 	// Create a request for a value.
 	testFrame.identifier = 0x18CB86F7;
@@ -1247,7 +1231,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1269,7 +1253,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x02;
 	testFrame.data[6] = 0x03;
 	testFrame.data[7] = 0x04;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1292,7 +1276,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x07;
 	testFrame.data[6] = 0x06;
 	testFrame.data[7] = 0x05;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1319,7 +1303,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 	// This time the callback should be gone.
@@ -1347,7 +1331,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x02;
 	testFrame.data[6] = 0x03;
 	testFrame.data[7] = 0x04;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1370,7 +1354,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1398,7 +1382,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1422,7 +1406,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1446,7 +1430,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::CANNetwork.can_lib_process_rx_message(testFrame, nullptr);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 

--- a/utility/include/isobus/utility/event_dispatcher.hpp
+++ b/utility/include/isobus/utility/event_dispatcher.hpp
@@ -29,7 +29,7 @@ namespace isobus
 		/// @brief Register a callback to be invoked when the event is invoked.
 		/// @param callback The callback to register.
 		/// @return A shared pointer to the callback.
-		std::shared_ptr<std::function<void(const E &...)>> add_listener(std::function<void(const E &...)> &callback)
+		std::shared_ptr<std::function<void(const E &...)>> add_listener(const std::function<void(const E &...)> &callback)
 		{
 			std::lock_guard<std::mutex> lock(callbacksMutex);
 			auto shared = std::make_shared<std::function<void(const E &...)>>(callback);
@@ -42,7 +42,7 @@ namespace isobus
 		/// @param context The context object to pass through to the callback.
 		/// @return A shared pointer to the contextless callback.
 		template<typename C>
-		std::shared_ptr<std::function<void(const E &...)>> add_listener(std::function<void(const E &..., std::shared_ptr<C>)> &callback, std::weak_ptr<C> context)
+		std::shared_ptr<std::function<void(const E &...)>> add_listener(const std::function<void(const E &..., std::shared_ptr<C>)> &callback, std::weak_ptr<C> context)
 		{
 			std::function<void(const E &...)> callbackWrapper = [callback, context](const E &...args) {
 				if (auto contextPtr = context.lock())
@@ -58,7 +58,7 @@ namespace isobus
 		/// @param context The context object to pass through to the callback.
 		/// @return A shared pointer to the contextless callback.
 		template<typename C>
-		std::shared_ptr<std::function<void(const E &...)>> add_unsafe_listener(std::function<void(const E &..., std::weak_ptr<C>)> &callback, std::weak_ptr<C> context)
+		std::shared_ptr<std::function<void(const E &...)>> add_unsafe_listener(const std::function<void(const E &..., std::weak_ptr<C>)> &callback, std::weak_ptr<C> context)
 		{
 			std::function<void(const E &...)> callbackWrapper = [callback, context](const E &...args) {
 				callback(args..., context);


### PR DESCRIPTION
## Changelog:
HardwareInterface:
- Major:
  - Call `CANNetworkManager::update()` directly by default
  - Call `CANNetworkManager::can_lib_process_rx_message()` directly by default
  - Use `EventDispatcher<>` for periodic update event
  - Use `EventDispatcher<isobus::HardwareInterfaceCANFrame>` for received/transmitted can frame event
  - Add `get_periodic_update_interval()` to get interval between periodic updates
  - Add more test cases for hardware interface
- Minor:
  - Renamed `can_thread` to `update_thread` 
  - Renamed `threadMutex` to `updateMutex`
  - Renamed `canLibNeedsUpdate` to `stackNeedsUpdate`
  - Renamed `periodicUpdateThread` to `wakeupThread`
  - Renamed `canLibUpdatePeriod` to `periodicUpdateInterval`
  - General optimizations to `update_thread_function` 

HardwareAbstraction:
- Renamed `send_can_message_to_hardware` to `send_can_message_frame_to_hardware`
- Added `receive_can_message_frame_from_hardware` as an abstraction layer
- Added `periodic_update_from_hardware` as an abstraction layer