### PR TITLE
[VT]: Add functions to get active masks

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -1071,6 +1071,14 @@ namespace isobus
 		/// @returns true if the VT version is supported by the VT server
 		bool get_vt_version_supported(VTVersion value) const;
 
+		/// @brief Returns the current data mask displayed by the VT server
+		/// @returns The object ID of the data mask visible
+		std::uint16_t get_visible_data_mask() const;
+
+		/// @brief Returns the current soft key mask displayed by the VT server
+		/// @returns The object ID of the soft key mask visible
+		std::uint16_t get_visible_soft_key_mask() const;
+
 		// ************************************************
 		// Object Pool Interface
 		// ************************************************
@@ -1539,7 +1547,7 @@ namespace isobus
 		// Status message contents from the VT
 		std::uint32_t lastVTStatusTimestamp_ms; ///< The timestamp of the last VT status message
 		std::uint16_t activeWorkingSetDataMaskObjectID; ///< The active working set data mask object ID
-		std::uint16_t activeWorkingSetSoftkeyMaskObjectID; ///< The active working set's softkey mask object ID
+		std::uint16_t activeWorkingSetSoftKeyMaskObjectID; ///< The active working set's softkey mask object ID
 		std::uint8_t activeWorkingSetMasterAddress; ///< The active working set master address
 		std::uint8_t busyCodesBitfield; ///< The VT server's busy codes
 		std::uint8_t currentCommandFunctionCode; ///< The VT server's current command function code

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -30,7 +30,7 @@ namespace isobus
 	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberFlags), process_flags, this),
 	  lastVTStatusTimestamp_ms(0),
 	  activeWorkingSetDataMaskObjectID(NULL_OBJECT_ID),
-	  activeWorkingSetSoftkeyMaskObjectID(NULL_OBJECT_ID),
+	  activeWorkingSetSoftKeyMaskObjectID(NULL_OBJECT_ID),
 	  activeWorkingSetMasterAddress(NULL_CAN_ADDRESS),
 	  busyCodesBitfield(0),
 	  currentCommandFunctionCode(0),
@@ -1410,6 +1410,16 @@ namespace isobus
 		}
 
 		return retVal;
+	}
+
+	std::uint16_t VirtualTerminalClient::get_visible_data_mask() const
+	{
+		return activeWorkingSetDataMaskObjectID;
+	}
+
+	std::uint16_t VirtualTerminalClient::get_visible_soft_key_mask() const
+	{
+		return activeWorkingSetSoftKeyMaskObjectID;
 	}
 
 	void VirtualTerminalClient::set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::uint8_t *pool, std::uint32_t size, std::string version)
@@ -2926,7 +2936,7 @@ namespace isobus
 							parentVT->lastVTStatusTimestamp_ms = SystemTiming::get_timestamp_ms();
 							parentVT->activeWorkingSetMasterAddress = message->get_uint8_at(1);
 							parentVT->activeWorkingSetDataMaskObjectID = message->get_uint16_at(2);
-							parentVT->activeWorkingSetSoftkeyMaskObjectID = message->get_uint16_at(4);
+							parentVT->activeWorkingSetSoftKeyMaskObjectID = message->get_uint16_at(4);
 							parentVT->busyCodesBitfield = message->get_uint8_at(6);
 							parentVT->currentCommandFunctionCode = message->get_uint8_at(7);
 						}

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -126,8 +126,9 @@ TEST(VIRTUAL_TERMINAL_TESTS, VTStatusMessage)
 
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
-	EXPECT_EQ(VirtualTerminalClient::NULL_OBJECT_ID, clientUnderTest.get_visible_data_mask());
-	EXPECT_EQ(VirtualTerminalClient::NULL_OBJECT_ID, clientUnderTest.get_visible_soft_key_mask());
+	static constexpr std::uint16_t NULL_OBJECT_ID = isobus::VirtualTerminalClient::NULL_OBJECT_ID;
+	EXPECT_EQ(NULL_OBJECT_ID, clientUnderTest.get_visible_data_mask());
+	EXPECT_EQ(NULL_OBJECT_ID, clientUnderTest.get_visible_soft_key_mask());
 
 	CANLibManagedMessage testMessage(0);
 	testMessage.set_identifier(CANIdentifier(CANIdentifier::Type::Extended, static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), CANIdentifier::PriorityDefault6, 0, 0));


### PR DESCRIPTION
This should help with optimizations at application level, as you now are able to know which mask is active. This can be used for example, to only send updates to a mask that is active.