### PR TITLE
[Core]: Add Hardware Integration to isobus namespace

### DIFF
--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -22,15 +22,15 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<SocketCANInterface>("can0");
+	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 #elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 #elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 #endif
 	if (nullptr == canDriver)
 	{
@@ -39,10 +39,10 @@ int main()
 		return -1;
 	}
 
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+	isobus::CANHardwareInterface::set_number_of_can_channels(1);
+	isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
@@ -120,7 +120,7 @@ int main()
 		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 	}
 
-	CANHardwareInterface::stop();
+	isobus::CANHardwareInterface::stop();
 	isobus::DiagnosticProtocol::deassign_all_diagnostic_protocol_to_internal_control_functions();
 	return 0;
 }

--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -44,15 +44,15 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<SocketCANInterface>("can0");
+	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 #elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 #elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 #endif
 	if (nullptr == canDriver)
 	{
@@ -61,10 +61,10 @@ int main()
 		return -1;
 	}
 
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+	isobus::CANHardwareInterface::set_number_of_can_channels(1);
+	isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to start hardware interface. A CAN driver might be invalid." << std::endl;
 		return -2;
@@ -111,7 +111,7 @@ int main()
 		std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 	}
 
-	CANHardwareInterface::stop();
+	isobus::CANHardwareInterface::stop();
 	isobus::FastPacketProtocol::Protocol.remove_multipacket_message_callback(0x1F001, nmea2k_callback, nullptr);
 	return 0;
 }

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -83,15 +83,15 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<SocketCANInterface>("can0");
+	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 #elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 #elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 #endif
 	if (nullptr == canDriver)
 	{
@@ -100,10 +100,10 @@ int main()
 		return -1;
 	}
 
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+	isobus::CANHardwareInterface::set_number_of_can_channels(1);
+	isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid" << std::endl;
 		return -2;
@@ -175,7 +175,7 @@ int main()
 		}
 	}
 
-	CANHardwareInterface::stop();
+	isobus::CANHardwareInterface::stop();
 
 	return 0;
 }

--- a/examples/task_controller_client/main.cpp
+++ b/examples/task_controller_client/main.cpp
@@ -30,15 +30,15 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<SocketCANInterface>("can0");
+	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 #elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 #elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 #endif
 	if (nullptr == canDriver)
 	{
@@ -49,10 +49,10 @@ int main()
 
 	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
 	isobus::CANStackLogger::set_log_level(isobus::CANStackLogger::LoggingLevel::Debug); // Change this to Debug to see more information
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+	isobus::CANHardwareInterface::set_number_of_can_channels(1);
+	isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
@@ -113,6 +113,6 @@ int main()
 	}
 
 	TestTCClient->terminate();
-	CANHardwareInterface::stop();
+	isobus::CANHardwareInterface::stop();
 	return (!tcClientStarted);
 }

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -26,15 +26,15 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<SocketCANInterface>("can0");
+	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 #elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 #elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 #endif
 	if (nullptr == canDriver)
 	{
@@ -43,10 +43,10 @@ int main()
 		return -1;
 	}
 
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+	isobus::CANHardwareInterface::set_number_of_can_channels(1);
+	isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
@@ -159,7 +159,7 @@ int main()
 		std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 	}
 
-	CANHardwareInterface::stop();
+	isobus::CANHardwareInterface::stop();
 
 	return 0;
 }

--- a/examples/virtual_terminal/aux_functions/main.cpp
+++ b/examples/virtual_terminal/aux_functions/main.cpp
@@ -34,15 +34,15 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<SocketCANInterface>("can0");
+	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 #elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 #elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 #endif
 	if (nullptr == canDriver)
 	{
@@ -53,10 +53,10 @@ int main()
 
 	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
 	isobus::CANStackLogger::set_log_level(isobus::CANStackLogger::LoggingLevel::Info); // Change this to Debug to see more information
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+	isobus::CANHardwareInterface::set_number_of_can_channels(1);
+	isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
@@ -110,6 +110,6 @@ int main()
 	}
 
 	TestVirtualTerminalClient->terminate();
-	CANHardwareInterface::stop();
+	isobus::CANHardwareInterface::stop();
 	return 0;
 }

--- a/examples/virtual_terminal/aux_inputs/main.cpp
+++ b/examples/virtual_terminal/aux_inputs/main.cpp
@@ -96,15 +96,15 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<SocketCANInterface>("can0");
+	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 #elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 #elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 #endif
 	if (nullptr == canDriver)
 	{
@@ -115,16 +115,16 @@ int main()
 
 	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
 	isobus::CANStackLogger::set_log_level(isobus::CANStackLogger::LoggingLevel::Info); // Change this to Debug to see more information
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+	isobus::CANHardwareInterface::set_number_of_can_channels(1);
+	isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
 	}
 
-	auto updateListener = CANHardwareInterface::get_periodic_update_event_dispatcher().add_listener(on_periodic_update);
+	auto updateListener = isobus::CANHardwareInterface::get_periodic_update_event_dispatcher().add_listener(on_periodic_update);
 	std::this_thread::sleep_for(std::chrono::milliseconds(250));
 
 	isobus::NAME TestDeviceNAME(0);
@@ -175,6 +175,6 @@ int main()
 	}
 
 	TestVirtualTerminalClient->terminate();
-	CANHardwareInterface::stop();
+	isobus::CANHardwareInterface::stop();
 	return 0;
 }

--- a/examples/virtual_terminal/version3_object_pool/main.cpp
+++ b/examples/virtual_terminal/version3_object_pool/main.cpp
@@ -76,15 +76,15 @@ int main()
 	std::signal(SIGINT, signal_handler);
 
 	// Automatically load the desired CAN driver based on the available drivers
-	std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<SocketCANInterface>("can0");
+	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 #elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 #elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 #endif
 	if (nullptr == canDriver)
 	{
@@ -95,10 +95,10 @@ int main()
 
 	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
 	isobus::CANStackLogger::set_log_level(isobus::CANStackLogger::LoggingLevel::Info); // Change this to Debug to see more information
-	CANHardwareInterface::set_number_of_can_channels(1);
-	CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+	isobus::CANHardwareInterface::set_number_of_can_channels(1);
+	isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-	if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 	{
 		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 		return -2;
@@ -150,6 +150,6 @@ int main()
 	}
 
 	TestVirtualTerminalClient->terminate();
-	CANHardwareInterface::stop();
+	isobus::CANHardwareInterface::stop();
 	return 0;
 }

--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -23,141 +23,143 @@
 #include "isobus/isobus/can_hardware_abstraction.hpp"
 #include "isobus/utility/event_dispatcher.hpp"
 
-//================================================================================================
-/// @class CANHardwareInterface
-///
-/// @brief Provides a common queuing and thread layer for running the CAN stack and all CAN drivers
-///
-/// @details The `CANHardwareInterface` class was created to provide a common queuing and thread
-/// layer for running the CAN stack and all CAN drivers to simplify integration and crucially to
-/// provide a consistent, safe order of operations for all the function calls needed to properly
-/// drive the stack.
-//================================================================================================
-class CANHardwareInterface
+namespace isobus
 {
-public:
-	/// @brief Returns the number of configured CAN channels that the class is managing
-	/// @returns The number of configured CAN channels that the class is managing
-	static std::uint8_t get_number_of_can_channels();
-
-	/// @brief Sets the number of CAN channels to manage
-	/// @details Allocates the proper number of `CanHardware` objects to track
-	/// each CAN channel's Tx and Rx message queues. If you pass in a smaller number than what was
-	/// already configured, it will delete the unneeded `CanHardware` objects.
-	/// @note The function will fail if the channel is already assigned to a driver or the interface is already started
-	/// @param value The number of CAN channels to manage
-	/// @returns `true` if the channel count was set, otherwise `false`.
-	static bool set_number_of_can_channels(std::uint8_t value);
-
-	/// @brief Assigns a CAN driver to a channel
-	/// @param[in] channelIndex The channel to assign to
-	/// @param[in] canDriver The driver to assign to the channel
-	/// @note The function will fail if the channel is already assigned to a driver or the interface is already started
-	/// @returns `true` if the driver was assigned to the channel, otherwise `false`
-	static bool assign_can_channel_frame_handler(std::uint8_t channelIndex, std::shared_ptr<CANHardwarePlugin> canDriver);
-
-	/// @brief Removes a CAN driver from a channel
-	/// @param[in] channelIndex The channel to remove the driver from
-	/// @note The function will fail if the channel is already assigned to a driver or the interface is already started
-	/// @returns `true` if the driver was removed from the channel, otherwise `false`
-	static bool unassign_can_channel_frame_handler(std::uint8_t channelIndex);
-
-	/// @brief Starts the threads for managing the CAN stack and CAN drivers
-	/// @returns `true` if the threads were started, otherwise false (perhaps they are already running)
-	static bool start();
-
-	/// @brief Stops all CAN management threads and discards all remaining messages in the Tx and Rx queues.
-	/// @returns `true` if the threads were stopped, otherwise `false`
-	static bool stop();
-
-	/// @brief Checks if the CAN stack and CAN drivers are running
-	/// @returns `true` if the threads are running, otherwise `false`
-	static bool is_running();
-
-	/// @brief Called externally, adds a message to a CAN channel's Tx queue
-	/// @param[in] packet The packet to add to the Tx queue
-	/// @returns `true` if the packet was accepted, otherwise `false` (maybe wrong channel assigned)
-	static bool transmit_can_message(const isobus::HardwareInterfaceCANFrame &packet);
-
-	/// @brief Get the event dispatcher for when a CAN message frame is received from hardware event
-	/// @returns The event dispatcher which can be used to register callbacks/listeners to
-	static isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> &get_can_frame_received_event_dispatcher();
-
-	/// @brief Get the event dispatcher for when a CAN message frame will be send to hardware event
-	/// @returns The event dispatcher which can be used to register callbacks/listeners to
-	static isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> &get_can_frame_transmitted_event_dispatcher();
-
-	/// @brief Get the event dispatcher for when a periodic update is called
-	/// @returns The event dispatcher which can be used to register callbacks/listeners to
-	static isobus::EventDispatcher<> &get_periodic_update_event_dispatcher();
-
-	/// @brief Set the interval between periodic updates
-	/// @param[in] value The interval between update calls in milliseconds
-	static void set_periodic_update_interval(std::uint32_t value);
-
-	/// @brief Get the interval between periodic updates
-	/// @returns The interval between update calls in milliseconds
-	static std::uint32_t get_periodic_update_interval();
-
-private:
-	/// @brief Stores the Tx/Rx queues, mutexes, and driver needed to run a single CAN channel
-	struct CANHardware
+	//================================================================================================
+	/// @class CANHardwareInterface
+	///
+	/// @brief Provides a common queuing and thread layer for running the CAN stack and all CAN drivers
+	///
+	/// @details The `CANHardwareInterface` class was created to provide a common queuing and thread
+	/// layer for running the CAN stack and all CAN drivers to simplify integration and crucially to
+	/// provide a consistent, safe order of operations for all the function calls needed to properly
+	/// drive the stack.
+	//================================================================================================
+	class CANHardwareInterface
 	{
-		std::mutex messagesToBeTransmittedMutex; ///< Mutex to protect the Tx queue
-		std::deque<isobus::HardwareInterfaceCANFrame> messagesToBeTransmitted; ///< Tx message queue for a CAN channel
+	public:
+		/// @brief Returns the number of configured CAN channels that the class is managing
+		/// @returns The number of configured CAN channels that the class is managing
+		static std::uint8_t get_number_of_can_channels();
 
-		std::mutex receivedMessagesMutex; ///< Mutex to protect the Rx queue
-		std::deque<isobus::HardwareInterfaceCANFrame> receivedMessages; ///< Rx message queue for a CAN channel
+		/// @brief Sets the number of CAN channels to manage
+		/// @details Allocates the proper number of `CanHardware` objects to track
+		/// each CAN channel's Tx and Rx message queues. If you pass in a smaller number than what was
+		/// already configured, it will delete the unneeded `CanHardware` objects.
+		/// @note The function will fail if the channel is already assigned to a driver or the interface is already started
+		/// @param value The number of CAN channels to manage
+		/// @returns `true` if the channel count was set, otherwise `false`.
+		static bool set_number_of_can_channels(std::uint8_t value);
 
-		std::unique_ptr<std::thread> receiveMessageThread; ///< Thread to manage getting messages from a CAN channel
+		/// @brief Assigns a CAN driver to a channel
+		/// @param[in] channelIndex The channel to assign to
+		/// @param[in] canDriver The driver to assign to the channel
+		/// @note The function will fail if the channel is already assigned to a driver or the interface is already started
+		/// @returns `true` if the driver was assigned to the channel, otherwise `false`
+		static bool assign_can_channel_frame_handler(std::uint8_t channelIndex, std::shared_ptr<CANHardwarePlugin> canDriver);
 
-		std::shared_ptr<CANHardwarePlugin> frameHandler; ///< The CAN driver to use for a CAN channel
+		/// @brief Removes a CAN driver from a channel
+		/// @param[in] channelIndex The channel to remove the driver from
+		/// @note The function will fail if the channel is already assigned to a driver or the interface is already started
+		/// @returns `true` if the driver was removed from the channel, otherwise `false`
+		static bool unassign_can_channel_frame_handler(std::uint8_t channelIndex);
+
+		/// @brief Starts the threads for managing the CAN stack and CAN drivers
+		/// @returns `true` if the threads were started, otherwise false (perhaps they are already running)
+		static bool start();
+
+		/// @brief Stops all CAN management threads and discards all remaining messages in the Tx and Rx queues.
+		/// @returns `true` if the threads were stopped, otherwise `false`
+		static bool stop();
+
+		/// @brief Checks if the CAN stack and CAN drivers are running
+		/// @returns `true` if the threads are running, otherwise `false`
+		static bool is_running();
+
+		/// @brief Called externally, adds a message to a CAN channel's Tx queue
+		/// @param[in] packet The packet to add to the Tx queue
+		/// @returns `true` if the packet was accepted, otherwise `false` (maybe wrong channel assigned)
+		static bool transmit_can_message(const isobus::HardwareInterfaceCANFrame &packet);
+
+		/// @brief Get the event dispatcher for when a CAN message frame is received from hardware event
+		/// @returns The event dispatcher which can be used to register callbacks/listeners to
+		static isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> &get_can_frame_received_event_dispatcher();
+
+		/// @brief Get the event dispatcher for when a CAN message frame will be send to hardware event
+		/// @returns The event dispatcher which can be used to register callbacks/listeners to
+		static isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> &get_can_frame_transmitted_event_dispatcher();
+
+		/// @brief Get the event dispatcher for when a periodic update is called
+		/// @returns The event dispatcher which can be used to register callbacks/listeners to
+		static isobus::EventDispatcher<> &get_periodic_update_event_dispatcher();
+
+		/// @brief Set the interval between periodic updates
+		/// @param[in] value The interval between update calls in milliseconds
+		static void set_periodic_update_interval(std::uint32_t value);
+
+		/// @brief Get the interval between periodic updates
+		/// @returns The interval between update calls in milliseconds
+		static std::uint32_t get_periodic_update_interval();
+
+	private:
+		/// @brief Stores the Tx/Rx queues, mutexes, and driver needed to run a single CAN channel
+		struct CANHardware
+		{
+			std::mutex messagesToBeTransmittedMutex; ///< Mutex to protect the Tx queue
+			std::deque<isobus::HardwareInterfaceCANFrame> messagesToBeTransmitted; ///< Tx message queue for a CAN channel
+
+			std::mutex receivedMessagesMutex; ///< Mutex to protect the Rx queue
+			std::deque<isobus::HardwareInterfaceCANFrame> receivedMessages; ///< Rx message queue for a CAN channel
+
+			std::unique_ptr<std::thread> receiveMessageThread; ///< Thread to manage getting messages from a CAN channel
+
+			std::shared_ptr<CANHardwarePlugin> frameHandler; ///< The CAN driver to use for a CAN channel
+		};
+
+		/// @brief Singleton instance of the CANHardwareInterface class
+		/// @details This is a little hack that allows to have the destructor called
+		static CANHardwareInterface SINGLETON;
+
+		/// @brief Constructor for the CANHardwareInterface class
+		CANHardwareInterface() = default;
+
+		/// @brief Deconstructor for the CANHardwareInterface class
+		virtual ~CANHardwareInterface();
+
+		/// @brief The default update interval for the CAN stack. Mostly arbitrary
+		static constexpr std::uint32_t PERIODIC_UPDATE_INTERVAL = 4;
+
+		/// @brief The main CAN thread executes this function. Does most of the work of this class
+		static void update_thread_function();
+
+		/// @brief The receive thread(s) execute this function
+		/// @param[in] channelIndex The associated CAN channel for the thread
+		static void receive_message_thread_function(std::uint8_t channelIndex);
+
+		/// @brief Attempts to write a frame using the driver assigned to a packet's channel
+		/// @param[in] packet The packet to try and write to the bus
+		static bool transmit_can_message_from_buffer(isobus::HardwareInterfaceCANFrame &packet);
+
+		/// @brief The periodic update thread executes this function
+		static void periodic_update_function();
+
+		/// @brief Stops all threads related to the hardware interface
+		static void stop_threads();
+
+		static std::unique_ptr<std::thread> updateThread; ///< The main thread
+		static std::unique_ptr<std::thread> wakeupThread; ///< A thread that periodically wakes up the `updateThread`
+		static std::condition_variable updateThreadWakeupCondition; ///< A condition variable to allow for signaling the `updateThread` to wakeup
+		static std::atomic_bool stackNeedsUpdate; ///< Stores if the CAN thread needs to update the stack this iteration
+		static std::uint32_t periodicUpdateInterval; ///< The period between calls to the CAN stack update function in milliseconds
+
+		static isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> frameReceivedEventDispatcher; ///< The event dispatcher for when a CAN message frame is received from hardware event
+		static isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> frameTransmittedEventDispatcher; ///< The event dispatcher for when a CAN message has been transmitted via hardware
+		static isobus::EventDispatcher<> periodicUpdateEventDispatcher; ///< The event dispatcher for when a periodic update is called
+
+		static std::vector<std::unique_ptr<CANHardware>> hardwareChannels; ///< A list of all CAN channel's metadata
+		static std::mutex hardwareChannelsMutex; ///< Mutex to protect `hardwareChannels`
+		static std::mutex updateMutex; ///< A mutex for the main thread
+		static std::atomic_bool threadsStarted; ///< Stores if the threads have been started
 	};
-
-	/// @brief Singleton instance of the CANHardwareInterface class
-	/// @details This is a little hack that allows to have the destructor called
-	static CANHardwareInterface SINGLETON;
-
-	/// @brief Constructor for the CANHardwareInterface class
-	CANHardwareInterface() = default;
-
-	/// @brief Deconstructor for the CANHardwareInterface class
-	virtual ~CANHardwareInterface();
-
-	/// @brief The default update interval for the CAN stack. Mostly arbitrary
-	static constexpr std::uint32_t PERIODIC_UPDATE_INTERVAL = 4;
-
-	/// @brief The main CAN thread executes this function. Does most of the work of this class
-	static void update_thread_function();
-
-	/// @brief The receive thread(s) execute this function
-	/// @param[in] channelIndex The associated CAN channel for the thread
-	static void receive_message_thread_function(std::uint8_t channelIndex);
-
-	/// @brief Attempts to write a frame using the driver assigned to a packet's channel
-	/// @param[in] packet The packet to try and write to the bus
-	static bool transmit_can_message_from_buffer(isobus::HardwareInterfaceCANFrame &packet);
-
-	/// @brief The periodic update thread executes this function
-	static void periodic_update_function();
-
-	/// @brief Stops all threads related to the hardware interface
-	static void stop_threads();
-
-	static std::unique_ptr<std::thread> updateThread; ///< The main thread
-	static std::unique_ptr<std::thread> wakeupThread; ///< A thread that periodically wakes up the `updateThread`
-	static std::condition_variable updateThreadWakeupCondition; ///< A condition variable to allow for signaling the `updateThread` to wakeup
-	static std::atomic_bool stackNeedsUpdate; ///< Stores if the CAN thread needs to update the stack this iteration
-	static std::uint32_t periodicUpdateInterval; ///< The period between calls to the CAN stack update function in milliseconds
-
-	static isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> frameReceivedEventDispatcher; ///< The event dispatcher for when a CAN message frame is received from hardware event
-	static isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> frameTransmittedEventDispatcher; ///< The event dispatcher for when a CAN message has been transmitted via hardware
-	static isobus::EventDispatcher<> periodicUpdateEventDispatcher; ///< The event dispatcher for when a periodic update is called
-
-	static std::vector<std::unique_ptr<CANHardware>> hardwareChannels; ///< A list of all CAN channel's metadata
-	static std::mutex hardwareChannelsMutex; ///< Mutex to protect `hardwareChannels`
-	static std::mutex updateMutex; ///< A mutex for the main thread
-	static std::atomic_bool threadsStarted; ///< Stores if the threads have been started
-};
-
+}
 #endif // CAN_HARDWARE_INTERFACE_HPP

--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_plugin.hpp
@@ -11,35 +11,37 @@
 
 #include "isobus/isobus/can_frame.hpp"
 
-//================================================================================================
-/// @class CANHardwarePlugin
-///
-/// @brief An abstract base class for a CAN driver
-//================================================================================================
-class CANHardwarePlugin
+namespace isobus
 {
-public:
-	/// @brief Returns if the driver is ready and in a good state
-	/// @details This should return `false` until `open` is called, and after `close` is called, or
-	/// if anything happens that causes the driver to be invalid, like the hardware is disconnected.
-	/// @returns `true` if the driver is good/connected, `false` if the driver is not usable
-	virtual bool get_is_valid() const = 0;
+	//================================================================================================
+	/// @class CANHardwarePlugin
+	///
+	/// @brief An abstract base class for a CAN driver
+	//================================================================================================
+	class CANHardwarePlugin
+	{
+	public:
+		/// @brief Returns if the driver is ready and in a good state
+		/// @details This should return `false` until `open` is called, and after `close` is called, or
+		/// if anything happens that causes the driver to be invalid, like the hardware is disconnected.
+		/// @returns `true` if the driver is good/connected, `false` if the driver is not usable
+		virtual bool get_is_valid() const = 0;
 
-	/// @brief Disconnects the driver from the hardware
-	virtual void close() = 0;
+		/// @brief Disconnects the driver from the hardware
+		virtual void close() = 0;
 
-	/// @brief Connects the driver to the hardware
-	virtual void open() = 0;
+		/// @brief Connects the driver to the hardware
+		virtual void open() = 0;
 
-	/// @brief Reads one frame from the bus synchronously
-	/// @param[in, out] canFrame The CAN frame that was read
-	/// @returns `true` if a CAN frame was read, otherwise `false`
-	virtual bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) = 0;
+		/// @brief Reads one frame from the bus synchronously
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		virtual bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) = 0;
 
-	/// @brief Writes a frame to the bus (synchronous)
-	/// @param[in] canFrame The frame to write to the bus
-	/// @returns `true` if the frame was written, otherwise `false`
-	virtual bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) = 0;
-};
-
+		/// @brief Writes a frame to the bus (synchronous)
+		/// @param[in] canFrame The frame to write to the bus
+		/// @returns `true` if the frame was written, otherwise `false`
+		virtual bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) = 0;
+	};
+}
 #endif // CAN_HARDEWARE_PLUGIN_HPP

--- a/hardware_integration/include/isobus/hardware_integration/innomaker_usb2can_windows_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/innomaker_usb2can_windows_plugin.hpp
@@ -20,73 +20,75 @@
 #include "isobus/isobus/can_frame.hpp"
 #include "isobus/isobus/can_hardware_abstraction.hpp"
 
-//================================================================================================
-/// @class InnoMakerUSB2CANWindowsPlugin
-///
-/// @brief A Windows CAN Driver for InnoMaker USB2CAN devices
-//================================================================================================
-class InnoMakerUSB2CANWindowsPlugin : public CANHardwarePlugin
+namespace isobus
 {
-public:
-	/// @brief The baudrates supported by the InnoMaker USB2CAN device
-	enum Baudrate
+	//================================================================================================
+	/// @class InnoMakerUSB2CANWindowsPlugin
+	///
+	/// @brief A Windows CAN Driver for InnoMaker USB2CAN devices
+	//================================================================================================
+	class InnoMakerUSB2CANWindowsPlugin : public CANHardwarePlugin
 	{
-		B20k, ///< 20 kbps baudrate
-		B33k3, ///< 33.3 kbps baudrate
-		B40k, ///< 40 kbps baudrate
-		B50k, ///< 50 kbps baudrate
-		B66k6, ///< 66.6 kbps baudrate
-		B80k, ///< 80 kbps baudrate
-		B83k3, ///< 83.3 kbps baudrate
-		B100k, ///< 100 kbps baudrate
-		B125k, ///< 125 kbps baudrate
-		B200k, ///< 200 kbps baudrate
-		B250k, ///< 250 kbps baudrate
-		B400k, ///< 400 kbps baudrate
-		B500k, ///< 500 kbps baudrate
-		B666k, ///< 666 kbps baudrate
-		B800k, ///< 800 kbps baudrate
-		B1000k, ///< 1000 kbps baudrate
+	public:
+		/// @brief The baudrates supported by the InnoMaker USB2CAN device
+		enum Baudrate
+		{
+			B20k, ///< 20 kbps baudrate
+			B33k3, ///< 33.3 kbps baudrate
+			B40k, ///< 40 kbps baudrate
+			B50k, ///< 50 kbps baudrate
+			B66k6, ///< 66.6 kbps baudrate
+			B80k, ///< 80 kbps baudrate
+			B83k3, ///< 83.3 kbps baudrate
+			B100k, ///< 100 kbps baudrate
+			B125k, ///< 125 kbps baudrate
+			B200k, ///< 200 kbps baudrate
+			B250k, ///< 250 kbps baudrate
+			B400k, ///< 400 kbps baudrate
+			B500k, ///< 500 kbps baudrate
+			B666k, ///< 666 kbps baudrate
+			B800k, ///< 800 kbps baudrate
+			B1000k, ///< 1000 kbps baudrate
+		};
+
+		/// @brief Constructor for the Windows version of the InnoMaker USB2CAN Windows CAN driver
+		/// @param[in] channel The channel to use by index, passed directly to the consuming driver
+		/// @param[in] baudrate The baud rate to configure the device for. Typically 250k baud
+		explicit InnoMakerUSB2CANWindowsPlugin(int channel, Baudrate baudrate = B250k);
+
+		/// @brief The destructor for InnoMakerUSB2CANWindowsPlugin
+		virtual ~InnoMakerUSB2CANWindowsPlugin();
+
+		/// @brief Returns if the connection with the hardware is valid
+		/// @returns `true` if connected, `false` if not connected
+		bool get_is_valid() const override;
+
+		/// @brief Closes the connection to the hardware
+		void close() override;
+
+		/// @brief Connects to the hardware you specified in the constructor's channel argument
+		void open() override;
+
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+		/// @brief Writes a frame to the bus (synchronous)
+		/// @param[in] canFrame The frame to write to the bus
+		/// @returns `true` if the frame was written, otherwise `false`
+		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+	private:
+		static constexpr InnoMakerUsb2CanLib::UsbCanMode CAN_MODE = InnoMakerUsb2CanLib::UsbCanModeNormal; ///< The mode to use for the CAN device
+		static constexpr std::uint32_t CAN_EFF_FLAG = 0x80000000; ///< Set if the frame is extended
+		static constexpr std::uint32_t CAN_SFF_MASK = 0x000007FF; ///< The mask for standard frames
+		static constexpr std::uint32_t CAN_EFF_MASK = 0x1FFFFFFF; ///< The mask for extended frames
+
+		static std::unique_ptr<InnoMakerUsb2CanLib> driverInstance; ///< The driver itself
+		const int channel; ///< Stores the channel associated with this object
+		const std::uint32_t baudrate; ///< Stores the baud rate associated with this object
+		std::unique_ptr<InnoMakerUsb2CanLib::innomaker_can> txContexts; ///< Stores Tx tickets for the driver
 	};
-
-	/// @brief Constructor for the Windows version of the InnoMaker USB2CAN Windows CAN driver
-	/// @param[in] channel The channel to use by index, passed directly to the consuming driver
-	/// @param[in] baudrate The baud rate to configure the device for. Typically 250k baud
-	explicit InnoMakerUSB2CANWindowsPlugin(int channel, Baudrate baudrate = B250k);
-
-	/// @brief The destructor for InnoMakerUSB2CANWindowsPlugin
-	virtual ~InnoMakerUSB2CANWindowsPlugin();
-
-	/// @brief Returns if the connection with the hardware is valid
-	/// @returns `true` if connected, `false` if not connected
-	bool get_is_valid() const override;
-
-	/// @brief Closes the connection to the hardware
-	void close() override;
-
-	/// @brief Connects to the hardware you specified in the constructor's channel argument
-	void open() override;
-
-	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
-	/// @param[in, out] canFrame The CAN frame that was read
-	/// @returns `true` if a CAN frame was read, otherwise `false`
-	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
-
-	/// @brief Writes a frame to the bus (synchronous)
-	/// @param[in] canFrame The frame to write to the bus
-	/// @returns `true` if the frame was written, otherwise `false`
-	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
-
-private:
-	static constexpr InnoMakerUsb2CanLib::UsbCanMode CAN_MODE = InnoMakerUsb2CanLib::UsbCanModeNormal; ///< The mode to use for the CAN device
-	static constexpr std::uint32_t CAN_EFF_FLAG = 0x80000000; ///< Set if the frame is extended
-	static constexpr std::uint32_t CAN_SFF_MASK = 0x000007FF; ///< The mask for standard frames
-	static constexpr std::uint32_t CAN_EFF_MASK = 0x1FFFFFFF; ///< The mask for extended frames
-
-	static std::unique_ptr<InnoMakerUsb2CanLib> driverInstance; ///< The driver itself
-	const int channel; ///< Stores the channel associated with this object
-	const std::uint32_t baudrate; ///< Stores the baud rate associated with this object
-	std::unique_ptr<InnoMakerUsb2CanLib::innomaker_can> txContexts; ///< Stores Tx tickets for the driver
-};
-
+}
 #endif // INNOMAKER_USB2CAN_PLUGIN_HPP

--- a/hardware_integration/include/isobus/hardware_integration/mac_can_pcan_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/mac_can_pcan_plugin.hpp
@@ -17,44 +17,46 @@
 #include "isobus/isobus/can_frame.hpp"
 #include "isobus/isobus/can_hardware_abstraction.hpp"
 
-//================================================================================================
-/// @class MacCANPCANPlugin
-///
-/// @brief A Mac OS CAN Driver for PEAK PCAN Devices
-//================================================================================================
-class MacCANPCANPlugin : public CANHardwarePlugin
+namespace isobus
 {
-public:
-	/// @brief Constructor for the MacCAN PCAN plugin
-	/// @param[in] channel The channel to use. See definitions in PCBUSB.h such as `PCAN_USBBUS1`
-	explicit MacCANPCANPlugin(WORD channel);
+	//================================================================================================
+	/// @class MacCANPCANPlugin
+	///
+	/// @brief A Mac OS CAN Driver for PEAK PCAN Devices
+	//================================================================================================
+	class MacCANPCANPlugin : public CANHardwarePlugin
+	{
+	public:
+		/// @brief Constructor for the MacCAN PCAN plugin
+		/// @param[in] channel The channel to use. See definitions in PCBUSB.h such as `PCAN_USBBUS1`
+		explicit MacCANPCANPlugin(WORD channel);
 
-	/// @brief The destructor for MacCANPCANPlugin
-	virtual ~MacCANPCANPlugin();
+		/// @brief The destructor for MacCANPCANPlugin
+		virtual ~MacCANPCANPlugin();
 
-	/// @brief Returns if the connection with the hardware is valid
-	/// @returns `true` if connected, `false` if not connected
-	bool get_is_valid() const override;
+		/// @brief Returns if the connection with the hardware is valid
+		/// @returns `true` if connected, `false` if not connected
+		bool get_is_valid() const override;
 
-	/// @brief Closes the connection to the hardware
-	void close() override;
+		/// @brief Closes the connection to the hardware
+		void close() override;
 
-	/// @brief Connects to the hardware you specified in the constructor's channel argument
-	void open() override;
+		/// @brief Connects to the hardware you specified in the constructor's channel argument
+		void open() override;
 
-	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
-	/// @param[in, out] canFrame The CAN frame that was read
-	/// @returns `true` if a CAN frame was read, otherwise `false`
-	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-	/// @brief Writes a frame to the bus (synchronous)
-	/// @param[in] canFrame The frame to write to the bus
-	/// @returns `true` if the frame was written, otherwise `false`
-	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Writes a frame to the bus (synchronous)
+		/// @param[in] canFrame The frame to write to the bus
+		/// @returns `true` if the frame was written, otherwise `false`
+		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-private:
-	TPCANHandle handle; ///< The handle as defined in the PCAN driver API
-	TPCANStatus openResult; ///< Stores the result of the call to begin CAN communication. Used for is_valid check later.
-};
-
+	private:
+		TPCANHandle handle; ///< The handle as defined in the PCAN driver API
+		TPCANStatus openResult; ///< Stores the result of the call to begin CAN communication. Used for is_valid check later.
+	};
+}
 #endif // MAC_CAN_PCAN_PLUGIN_HPP

--- a/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
@@ -20,160 +20,162 @@
 #include "isobus/isobus/can_frame.hpp"
 #include "isobus/isobus/can_hardware_abstraction.hpp"
 
-//================================================================================================
-/// @class MCP2515CANInterface
-///
-/// @brief A CAN Driver for the MCP2515 CAN controller
-//================================================================================================
-class MCP2515CANInterface : public CANHardwarePlugin
+namespace isobus
 {
-public:
-	/// @brief Constructor for the socket CAN driver
-	/// @param[in] transactionHandler The SPI transaction handler
-	/// @param[in] cfg1 The configuration value for CFG register 1
-	/// @param[in] cfg2 The configuration value for CFG register 2
-	/// @param[in] cfg3 The configuration value for CFG register 3
-	MCP2515CANInterface(SPIHardwarePlugin *transactionHandler, const std::uint8_t cfg1, const std::uint8_t cfg2, const std::uint8_t cfg3);
-
-	/// @brief The destructor for SocketCANInterface
-	virtual ~MCP2515CANInterface();
-
-	/// @brief Returns if the socket connection is valid
-	/// @returns `true` if connected, `false` if not connected
-	bool get_is_valid() const override;
-
-	/// @brief Closes the socket
-	void close() override;
-
-	/// @brief Connects to the socket
-	void open() override;
-
-	/// @brief Resets the MCP2515
-	bool reset();
-
-	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
-	/// @param[in, out] canFrame The CAN frame that was read
-	/// @returns `true` if a CAN frame was read, otherwise `false`
-	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
-
-	/// @brief Writes a frame to the bus (synchronous)
-	/// @param[in] canFrame The frame to write to the bus
-	/// @returns `true` if the frame was written, otherwise `false`
-	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
-
-private:
-	/// @brief Some essential instructions of the MCP2515
-	enum class MCPInstruction : std::uint8_t
+	//================================================================================================
+	/// @class MCP2515CANInterface
+	///
+	/// @brief A CAN Driver for the MCP2515 CAN controller
+	//================================================================================================
+	class MCP2515CANInterface : public CANHardwarePlugin
 	{
-		WRITE = 0x02,
-		READ = 0x03,
-		BITMOD = 0x05,
-		RX_STATUS = 0xB0,
-		READ_STATUS = 0xA0,
-		RESET = 0xC0
+	public:
+		/// @brief Constructor for the socket CAN driver
+		/// @param[in] transactionHandler The SPI transaction handler
+		/// @param[in] cfg1 The configuration value for CFG register 1
+		/// @param[in] cfg2 The configuration value for CFG register 2
+		/// @param[in] cfg3 The configuration value for CFG register 3
+		MCP2515CANInterface(SPIHardwarePlugin *transactionHandler, const std::uint8_t cfg1, const std::uint8_t cfg2, const std::uint8_t cfg3);
+
+		/// @brief The destructor for SocketCANInterface
+		virtual ~MCP2515CANInterface();
+
+		/// @brief Returns if the socket connection is valid
+		/// @returns `true` if connected, `false` if not connected
+		bool get_is_valid() const override;
+
+		/// @brief Closes the socket
+		void close() override;
+
+		/// @brief Connects to the socket
+		void open() override;
+
+		/// @brief Resets the MCP2515
+		bool reset();
+
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+		/// @brief Writes a frame to the bus (synchronous)
+		/// @param[in] canFrame The frame to write to the bus
+		/// @returns `true` if the frame was written, otherwise `false`
+		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+	private:
+		/// @brief Some essential instructions of the MCP2515
+		enum class MCPInstruction : std::uint8_t
+		{
+			WRITE = 0x02,
+			READ = 0x03,
+			BITMOD = 0x05,
+			RX_STATUS = 0xB0,
+			READ_STATUS = 0xA0,
+			RESET = 0xC0
+		};
+
+		/// @brief Some essential registers of the MCP2515
+		enum class MCPRegister : std::uint8_t
+		{
+			CANSTAT = 0x0E,
+			CANCTRL = 0x0F,
+			CNF3 = 0x28,
+			CNF2 = 0x29,
+			CNF1 = 0x2A,
+			CANINTE = 0x2B,
+			CANINTF = 0x2C,
+			TXB0CTRL = 0x30,
+			TXB0SIDH = 0x31,
+			TXB1CTRL = 0x40,
+			TXB1SIDH = 0x41,
+			TXB2CTRL = 0x50,
+			TXB2SIDH = 0x51,
+			RXB0CTRL = 0x60,
+			RXB0DATA = 0x66,
+			RXB1CTRL = 0x70,
+			RXB1DATA = 0x76
+		};
+
+		/// @brief The different modes of the MCP2515 associated with their internal bits
+		enum class MCPMode : std::uint8_t
+		{
+			NORMAL = 0x00,
+			SLEEP = 0x20,
+			LOOPBACK = 0x40,
+			LISTEN_ONLY = 0x60,
+			CONFIG = 0x80,
+		};
+
+		static constexpr std::uint32_t RECEIVE_MESSAGE_READ_RATE = 10; ///< Hardcoded time in ms between polling the MCP2515 module for new messages, mostly arbitrary
+
+		/// @brief Read the rx status of the mcp2515
+		/// @param[out] status The status that was read
+		/// @returns If the read was successfull
+		bool get_read_status(std::uint8_t &status);
+
+		/// @brief read a single byte register of the mcp2515
+		/// @param[in] address The address of the register to read
+		/// @param[out] data The data that was read
+		/// @returns If the read was successfull
+		bool read_register(const MCPRegister address, std::uint8_t &data);
+
+		/// @brief read multiple byte register of the mcp2515
+		/// @param[in] address The address of the register to read
+		/// @param[out] data The data that was read
+		/// @param[in] length The length of the data to read
+		/// @returns If the read was successfull
+		bool read_register(const MCPRegister address, std::uint8_t *data, const std::size_t length);
+
+		/// @brief modify a register of the mcp2515
+		/// @param[in] address The address of the register to modify
+		/// @param[in] mask The mask to apply to the register
+		/// @param[in] data The data to write to the register
+		/// @returns If the write was successfull
+		bool modify_register(const MCPRegister address, const std::uint8_t mask, const std::uint8_t data);
+
+		/// @brief write a single byte register of the mcp2515
+		/// @param[in] address The address of the register to write
+		/// @param[in] data The data to write to the register
+		/// @returns If the write was successfull
+		bool write_register(const MCPRegister address, const std::uint8_t data);
+
+		/// @brief write multiple byte register of the mcp2515
+		/// @param[in] address The address of the register to write
+		/// @param[in] data The data to write to the register
+		/// @param[in] length The length of the data to write to the register
+		/// @returns If the write was successfull
+		bool write_register(const MCPRegister address, const std::uint8_t data[], const std::size_t length);
+
+		/// @brief Reset the mcp2515 internally
+		/// @returns If the reset was successfull
+		bool write_reset();
+
+		/// @brief set the mode of the mcp2515
+		/// @param[in] mode The mode to set the mcp2515 to
+		/// @returns If the mode was set successfully
+		bool set_mode(const MCPMode mode);
+
+		/// @brief Read a frame from a buffer on the mcp2515
+		/// @param[in, out] canFrame The frame that was read
+		/// @param[in] ctrlRegister The control register of the buffer to read from
+		/// @param[in] dataRegister The data register of the buffer to read from
+		/// @param[in] intfMask The interrupt flag of the buffer to reset after reading
+		/// @returns If the read was successfull
+		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame, const MCPRegister ctrlRegister, const MCPRegister dataRegister, const std::uint8_t intfMask);
+
+		/// @brief Write a frame to a buffer on the mcp2515
+		/// @param[in] canFrame The frame to write
+		/// @param[in] ctrlRegister The control register of the buffer to write to
+		/// @param[in] sidhRegister The sidh register of the buffer to write to
+		/// @returns If the write was successfull
+		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame, const MCPRegister ctrlRegister, const MCPRegister sidhRegister);
+
+		SPIHardwarePlugin *transactionHandler; ///< The SPI transaction handler
+		const std::uint8_t cfg1; ///< Configuration value for CFG1 register
+		const std::uint8_t cfg2; ///< Configuration value for CFG2 register
+		const std::uint8_t cfg3; ///< Configuration value for CFG3 register
+		bool initialized; ///< If the mcp2515 has been initialized and no errors have occured
 	};
-
-	/// @brief Some essential registers of the MCP2515
-	enum class MCPRegister : std::uint8_t
-	{
-		CANSTAT = 0x0E,
-		CANCTRL = 0x0F,
-		CNF3 = 0x28,
-		CNF2 = 0x29,
-		CNF1 = 0x2A,
-		CANINTE = 0x2B,
-		CANINTF = 0x2C,
-		TXB0CTRL = 0x30,
-		TXB0SIDH = 0x31,
-		TXB1CTRL = 0x40,
-		TXB1SIDH = 0x41,
-		TXB2CTRL = 0x50,
-		TXB2SIDH = 0x51,
-		RXB0CTRL = 0x60,
-		RXB0DATA = 0x66,
-		RXB1CTRL = 0x70,
-		RXB1DATA = 0x76
-	};
-
-	/// @brief The different modes of the MCP2515 associated with their internal bits
-	enum class MCPMode : std::uint8_t
-	{
-		NORMAL = 0x00,
-		SLEEP = 0x20,
-		LOOPBACK = 0x40,
-		LISTEN_ONLY = 0x60,
-		CONFIG = 0x80,
-	};
-
-	static constexpr std::uint32_t RECEIVE_MESSAGE_READ_RATE = 10; ///< Hardcoded time in ms between polling the MCP2515 module for new messages, mostly arbitrary
-
-	/// @brief Read the rx status of the mcp2515
-	/// @param[out] status The status that was read
-	/// @returns If the read was successfull
-	bool get_read_status(std::uint8_t &status);
-
-	/// @brief read a single byte register of the mcp2515
-	/// @param[in] address The address of the register to read
-	/// @param[out] data The data that was read
-	/// @returns If the read was successfull
-	bool read_register(const MCPRegister address, std::uint8_t &data);
-
-	/// @brief read multiple byte register of the mcp2515
-	/// @param[in] address The address of the register to read
-	/// @param[out] data The data that was read
-	/// @param[in] length The length of the data to read
-	/// @returns If the read was successfull
-	bool read_register(const MCPRegister address, std::uint8_t *data, const std::size_t length);
-
-	/// @brief modify a register of the mcp2515
-	/// @param[in] address The address of the register to modify
-	/// @param[in] mask The mask to apply to the register
-	/// @param[in] data The data to write to the register
-	/// @returns If the write was successfull
-	bool modify_register(const MCPRegister address, const std::uint8_t mask, const std::uint8_t data);
-
-	/// @brief write a single byte register of the mcp2515
-	/// @param[in] address The address of the register to write
-	/// @param[in] data The data to write to the register
-	/// @returns If the write was successfull
-	bool write_register(const MCPRegister address, const std::uint8_t data);
-
-	/// @brief write multiple byte register of the mcp2515
-	/// @param[in] address The address of the register to write
-	/// @param[in] data The data to write to the register
-	/// @param[in] length The length of the data to write to the register
-	/// @returns If the write was successfull
-	bool write_register(const MCPRegister address, const std::uint8_t data[], const std::size_t length);
-
-	/// @brief Reset the mcp2515 internally
-	/// @returns If the reset was successfull
-	bool write_reset();
-
-	/// @brief set the mode of the mcp2515
-	/// @param[in] mode The mode to set the mcp2515 to
-	/// @returns If the mode was set successfully
-	bool set_mode(const MCPMode mode);
-
-	/// @brief Read a frame from a buffer on the mcp2515
-	/// @param[in, out] canFrame The frame that was read
-	/// @param[in] ctrlRegister The control register of the buffer to read from
-	/// @param[in] dataRegister The data register of the buffer to read from
-	/// @param[in] intfMask The interrupt flag of the buffer to reset after reading
-	/// @returns If the read was successfull
-	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame, const MCPRegister ctrlRegister, const MCPRegister dataRegister, const std::uint8_t intfMask);
-
-	/// @brief Write a frame to a buffer on the mcp2515
-	/// @param[in] canFrame The frame to write
-	/// @param[in] ctrlRegister The control register of the buffer to write to
-	/// @param[in] sidhRegister The sidh register of the buffer to write to
-	/// @returns If the write was successfull
-	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame, const MCPRegister ctrlRegister, const MCPRegister sidhRegister);
-
-	SPIHardwarePlugin *transactionHandler; ///< The SPI transaction handler
-	const std::uint8_t cfg1; ///< Configuration value for CFG1 register
-	const std::uint8_t cfg2; ///< Configuration value for CFG2 register
-	const std::uint8_t cfg3; ///< Configuration value for CFG3 register
-	bool initialized; ///< If the mcp2515 has been initialized and no errors have occured
-};
-
+}
 #endif // MCP2515_CAN_INTERFACE_HPP

--- a/hardware_integration/include/isobus/hardware_integration/pcan_basic_windows_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/pcan_basic_windows_plugin.hpp
@@ -22,44 +22,46 @@
 #include "isobus/isobus/can_frame.hpp"
 #include "isobus/isobus/can_hardware_abstraction.hpp"
 
-//================================================================================================
-/// @class PCANBasicWindowsPlugin
-///
-/// @brief A Windows CAN Driver for PEAK PCAN Devices
-//================================================================================================
-class PCANBasicWindowsPlugin : public CANHardwarePlugin
+namespace isobus
 {
-public:
-	/// @brief Constructor for the Windows version of the PEAK PCAN Basic CAN driver
-	/// @param[in] channel The channel to use. See definitions in PCANBasic.g such as `PCAN_USBBUS1`
-	explicit PCANBasicWindowsPlugin(WORD channel);
+	//================================================================================================
+	/// @class PCANBasicWindowsPlugin
+	///
+	/// @brief A Windows CAN Driver for PEAK PCAN Devices
+	//================================================================================================
+	class PCANBasicWindowsPlugin : public CANHardwarePlugin
+	{
+	public:
+		/// @brief Constructor for the Windows version of the PEAK PCAN Basic CAN driver
+		/// @param[in] channel The channel to use. See definitions in PCANBasic.g such as `PCAN_USBBUS1`
+		explicit PCANBasicWindowsPlugin(WORD channel);
 
-	/// @brief The destructor for PCANBasicWindowsPlugin
-	virtual ~PCANBasicWindowsPlugin();
+		/// @brief The destructor for PCANBasicWindowsPlugin
+		virtual ~PCANBasicWindowsPlugin();
 
-	/// @brief Returns if the connection with the hardware is valid
-	/// @returns `true` if connected, `false` if not connected
-	bool get_is_valid() const override;
+		/// @brief Returns if the connection with the hardware is valid
+		/// @returns `true` if connected, `false` if not connected
+		bool get_is_valid() const override;
 
-	/// @brief Closes the connection to the hardware
-	void close() override;
+		/// @brief Closes the connection to the hardware
+		void close() override;
 
-	/// @brief Connects to the hardware you specified in the constructor's channel argument
-	void open() override;
+		/// @brief Connects to the hardware you specified in the constructor's channel argument
+		void open() override;
 
-	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
-	/// @param[in, out] canFrame The CAN frame that was read
-	/// @returns `true` if a CAN frame was read, otherwise `false`
-	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-	/// @brief Writes a frame to the bus (synchronous)
-	/// @param[in] canFrame The frame to write to the bus
-	/// @returns `true` if the frame was written, otherwise `false`
-	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Writes a frame to the bus (synchronous)
+		/// @param[in] canFrame The frame to write to the bus
+		/// @returns `true` if the frame was written, otherwise `false`
+		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-private:
-	TPCANHandle handle; ///< The handle as defined in the PCAN driver API
-	TPCANStatus openResult; ///< Stores the result of the call to begin CAN communication. Used for is_valid check later.
-};
-
+	private:
+		TPCANHandle handle; ///< The handle as defined in the PCAN driver API
+		TPCANStatus openResult; ///< Stores the result of the call to begin CAN communication. Used for is_valid check later.
+	};
+}
 #endif // PCAN_BASIC_WINDOWS_PLUGIN_HPP

--- a/hardware_integration/include/isobus/hardware_integration/socket_can_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/socket_can_interface.hpp
@@ -16,49 +16,53 @@
 #include "isobus/isobus/can_frame.hpp"
 #include "isobus/isobus/can_hardware_abstraction.hpp"
 
-//================================================================================================
-/// @class SocketCANInterface
-///
-/// @brief A CAN Driver for Linux socket CAN
-//================================================================================================
-class SocketCANInterface : public CANHardwarePlugin
+struct sockaddr_can; ///< Forward declare the linux sockaddr_can struct
+
+namespace isobus
 {
-public:
-	/// @brief Constructor for the socket CAN driver
-	/// @param[in] deviceName The device name to use, like "can0" or "vcan0"
-	explicit SocketCANInterface(const std::string deviceName);
+	//================================================================================================
+	/// @class SocketCANInterface
+	///
+	/// @brief A CAN Driver for Linux socket CAN
+	//================================================================================================
+	class SocketCANInterface : public CANHardwarePlugin
+	{
+	public:
+		/// @brief Constructor for the socket CAN driver
+		/// @param[in] deviceName The device name to use, like "can0" or "vcan0"
+		explicit SocketCANInterface(const std::string deviceName);
 
-	/// @brief The destructor for SocketCANInterface
-	virtual ~SocketCANInterface();
+		/// @brief The destructor for SocketCANInterface
+		virtual ~SocketCANInterface();
 
-	/// @brief Returns if the socket connection is valid
-	/// @returns `true` if connected, `false` if not connected
-	bool get_is_valid() const override;
+		/// @brief Returns if the socket connection is valid
+		/// @returns `true` if connected, `false` if not connected
+		bool get_is_valid() const override;
 
-	/// @brief Returns the device name the driver is using
-	/// @returns The device name the driver is using, such as "can0" or "vcan0"
-	std::string get_device_name() const;
+		/// @brief Returns the device name the driver is using
+		/// @returns The device name the driver is using, such as "can0" or "vcan0"
+		std::string get_device_name() const;
 
-	/// @brief Closes the socket
-	void close() override;
+		/// @brief Closes the socket
+		void close() override;
 
-	/// @brief Connects to the socket
-	void open() override;
+		/// @brief Connects to the socket
+		void open() override;
 
-	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
-	/// @param[in, out] canFrame The CAN frame that was read
-	/// @returns `true` if a CAN frame was read, otherwise `false`
-	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-	/// @brief Writes a frame to the bus (synchronous)
-	/// @param[in] canFrame The frame to write to the bus
-	/// @returns `true` if the frame was written, otherwise `false`
-	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Writes a frame to the bus (synchronous)
+		/// @param[in] canFrame The frame to write to the bus
+		/// @returns `true` if the frame was written, otherwise `false`
+		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-private:
-	struct sockaddr_can *pCANDevice; ///< The structure for CAN sockets
-	const std::string name; ///< The device name
-	int fileDescriptor; ///< File descriptor for the socket
-};
-
+	private:
+		struct sockaddr_can *pCANDevice; ///< The structure for CAN sockets
+		const std::string name; ///< The device name
+		int fileDescriptor; ///< File descriptor for the socket
+	};
+}
 #endif // SOCKET_CAN_INTERFACE_HPP

--- a/hardware_integration/include/isobus/hardware_integration/spi_hardware_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/spi_hardware_plugin.hpp
@@ -16,29 +16,31 @@
 #include <cstdint>
 #include <vector>
 
-//================================================================================================
-/// @class SPIHardwarePlugin
-///
-/// @brief An abstract base class for SPI communication.
-//================================================================================================
-class SPIHardwarePlugin
+namespace isobus
 {
-public:
-	/// @brief Begin a transaction on the SPI bus. This should be called before any of the read/write operations.
-	/// @details Here the SPI bus can be acquired and prepared for a new transaction.
-	/// @note If any error occurs, end_transaction() should return false to mark a failed transaction
-	virtual void begin_transaction(){};
+	//================================================================================================
+	/// @class SPIHardwarePlugin
+	///
+	/// @brief An abstract base class for SPI communication.
+	//================================================================================================
+	class SPIHardwarePlugin
+	{
+	public:
+		/// @brief Begin a transaction on the SPI bus. This should be called before any of the read/write operations.
+		/// @details Here the SPI bus can be acquired and prepared for a new transaction.
+		/// @note If any error occurs, end_transaction() should return false to mark a failed transaction
+		virtual void begin_transaction(){};
 
-	/// @brief Write a frame to the SPI bus. This should only be called after begin_transaction().
-	/// The result should only be read after end_transaction().
-	/// @param frame A pointer to the frame to transmit
-	/// @note If any error occurs, end_transaction() should return false to mark a failed transaction.
-	virtual void transmit(SPITransactionFrame *frame) = 0;
+		/// @brief Write a frame to the SPI bus. This should only be called after begin_transaction().
+		/// The result should only be read after end_transaction().
+		/// @param frame A pointer to the frame to transmit
+		/// @note If any error occurs, end_transaction() should return false to mark a failed transaction.
+		virtual void transmit(SPITransactionFrame *frame) = 0;
 
-	/// @brief End a transaction on the SPI bus. This must be called after all write operations and before any read operation.
-	/// @details Here the SPI bus will be released and the transaction will be finalized.
-	/// @return True if the transaction was successful, false otherwise
-	virtual bool end_transaction() = 0;
-};
-
+		/// @brief End a transaction on the SPI bus. This must be called after all write operations and before any read operation.
+		/// @details Here the SPI bus will be released and the transaction will be finalized.
+		/// @return True if the transaction was successful, false otherwise
+		virtual bool end_transaction() = 0;
+	};
+}
 #endif // SPI_HARDWARE_PLUGIN_HPP

--- a/hardware_integration/include/isobus/hardware_integration/spi_interface_esp.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/spi_interface_esp.hpp
@@ -16,46 +16,48 @@
 #include "driver/spi_master.h"
 #include "freertos/semphr.h"
 
-//================================================================================================
-/// @class SPIInterfaceESP
-///
-/// @brief A driver for (synchronous) SPI communication on ESP platforms.
-//================================================================================================
-class SPIInterfaceESP : public SPIHardwarePlugin
+namespace isobus
 {
-public:
-	static constexpr std::uint32_t MAX_TIME_TO_WAIT = 5000 / portTICK_PERIOD_MS; ///< timeout of 5 seconds for spi related calls, mostly arbitrary.
+	//================================================================================================
+	/// @class SPIInterfaceESP
+	///
+	/// @brief A driver for (synchronous) SPI communication on ESP platforms.
+	//================================================================================================
+	class SPIInterfaceESP : public SPIHardwarePlugin
+	{
+	public:
+		static constexpr std::uint32_t MAX_TIME_TO_WAIT = 5000 / portTICK_PERIOD_MS; ///< timeout of 5 seconds for spi related calls, mostly arbitrary.
 
-	/// @brief Constructor of a SPI device on an ESP platform.
-	/// @param deviceConfig A pointer to the configuration of the SPI device
-	/// @param hostDevice The host device of the SPI device, e.g. SPI2_HOST
-	SPIInterfaceESP(const spi_device_interface_config_t *deviceConfig, const spi_host_device_t hostDevice);
+		/// @brief Constructor of a SPI device on an ESP platform.
+		/// @param deviceConfig A pointer to the configuration of the SPI device
+		/// @param hostDevice The host device of the SPI device, e.g. SPI2_HOST
+		SPIInterfaceESP(const spi_device_interface_config_t *deviceConfig, const spi_host_device_t hostDevice);
 
-	/// @brief Destructor of a SPI device on an ESP platform.
-	virtual ~SPIInterfaceESP();
+		/// @brief Destructor of a SPI device on an ESP platform.
+		virtual ~SPIInterfaceESP();
 
-	/// @brief Initialize the SPI device.
-	/// @return True if the initialization was successful, false otherwise
-	bool init();
+		/// @brief Initialize the SPI device.
+		/// @return True if the initialization was successful, false otherwise
+		bool init();
 
-	/// @brief Deinitialize the SPI device.
-	void deinit();
+		/// @brief Deinitialize the SPI device.
+		void deinit();
 
-	/// @brief Write (and read) a frame to the SPI bus
-	/// @param[in, out] frame A reference to the frame to transmit/receive
-	void transmit(SPITransactionFrame *frame) override;
+		/// @brief Write (and read) a frame to the SPI bus
+		/// @param[in, out] frame A reference to the frame to transmit/receive
+		void transmit(SPITransactionFrame *frame) override;
 
-	/// @brief End the transaction. This function returns the status since the last end_transaction().
-	/// @return True if the transaction was successful, false otherwise
-	bool end_transaction() override;
+		/// @brief End the transaction. This function returns the status since the last end_transaction().
+		/// @return True if the transaction was successful, false otherwise
+		bool end_transaction() override;
 
-private:
-	const spi_device_interface_config_t *deviceConfig; ///< The configuration of the SPI device
-	const spi_host_device_t hostDevice; ///< The host spi device
-	const SemaphoreHandle_t spiMutex; ///< A mutex to prevent concurrent access to the SPI bus
-	spi_device_handle_t spiDevice; ///< A handle to the SPI device
-	bool initialized; ///< The status of the device
-	bool success; ///< The status of the current transaction
-};
-
+	private:
+		const spi_device_interface_config_t *deviceConfig; ///< The configuration of the SPI device
+		const spi_host_device_t hostDevice; ///< The host spi device
+		const SemaphoreHandle_t spiMutex; ///< A mutex to prevent concurrent access to the SPI bus
+		spi_device_handle_t spiDevice; ///< A handle to the SPI device
+		bool initialized; ///< The status of the device
+		bool success; ///< The status of the current transaction
+	};
+}
 #endif // SPI_INTERFACE_ESP_SYNC_HPP

--- a/hardware_integration/include/isobus/hardware_integration/spi_transaction_frame.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/spi_transaction_frame.hpp
@@ -13,49 +13,52 @@
 #include <cstdint>
 #include <vector>
 
-//================================================================================================
-/// @class SPITransactionFrame
-///
-/// @brief A class containing the data for a single SPI transaction
-//================================================================================================
-class SPITransactionFrame
+namespace isobus
 {
-public:
-	/// @brief Construct a new SPITransactionFrame object
-	/// @param[in] txBuffer A pointer to the buffer to transmit
-	/// @param[in] read If true, the plugin will read the response to the write operation
-	SPITransactionFrame(const std::vector<std::uint8_t> *txBuffer, bool read = false);
+	//================================================================================================
+	/// @class SPITransactionFrame
+	///
+	/// @brief A class containing the data for a single SPI transaction
+	//================================================================================================
+	class SPITransactionFrame
+	{
+	public:
+		/// @brief Construct a new SPITransactionFrame object
+		/// @param[in] txBuffer A pointer to the buffer to transmit
+		/// @param[in] read If true, the plugin will read the response to the write operation
+		SPITransactionFrame(const std::vector<std::uint8_t> *txBuffer, bool read = false);
 
-	/// @brief Read a byte from the response buffer
-	/// @param[in] index The index of the byte to read
-	/// @param[in, out] byte The byte to store the read value in
-	/// @return True if the byte was read successfully, false otherwise
-	bool read_byte(std::size_t index, std::uint8_t &byte) const;
+		/// @brief Read a byte from the response buffer
+		/// @param[in] index The index of the byte to read
+		/// @param[in, out] byte The byte to store the read value in
+		/// @return True if the byte was read successfully, false otherwise
+		bool read_byte(std::size_t index, std::uint8_t &byte) const;
 
-	/// @brief Read multiple bytes from the response buffer
-	/// @param[in] index The index of the first byte to read
-	/// @param[in, out] buffer The buffer to store the bytes in
-	/// @param[in] length The number of bytes to read
-	/// @return True if the bytes were read successfully, false otherwise
-	bool read_bytes(std::size_t index, std::uint8_t *buffer, std::size_t length) const;
+		/// @brief Read multiple bytes from the response buffer
+		/// @param[in] index The index of the first byte to read
+		/// @param[in, out] buffer The buffer to store the bytes in
+		/// @param[in] length The number of bytes to read
+		/// @return True if the bytes were read successfully, false otherwise
+		bool read_bytes(std::size_t index, std::uint8_t *buffer, std::size_t length) const;
 
-	/// @brief Get the buffer to store the response in
-	/// @note This function should only be called by the spi interface
-	/// @return The buffer to store the response in
-	std::vector<std::uint8_t> &get_rx_buffer();
+		/// @brief Get the buffer to store the response in
+		/// @note This function should only be called by the spi interface
+		/// @return The buffer to store the response in
+		std::vector<std::uint8_t> &get_rx_buffer();
 
-	/// @brief Get the buffer to transmit
-	/// @note This function should only be called by the spi interface
-	/// @return The buffer to transmit
-	const std::vector<std::uint8_t> *get_tx_buffer() const;
+		/// @brief Get the buffer to transmit
+		/// @note This function should only be called by the spi interface
+		/// @return The buffer to transmit
+		const std::vector<std::uint8_t> *get_tx_buffer() const;
 
-	/// @brief Get whether the interface should read the response to the write operation
-	/// @return True if the interface should read the response to the write operation, false otherwise
-	bool get_is_read() const;
+		/// @brief Get whether the interface should read the response to the write operation
+		/// @return True if the interface should read the response to the write operation, false otherwise
+		bool get_is_read() const;
 
-private:
-	const std::vector<std::uint8_t> *txBuffer; ///< The buffer to transmit
-	const bool read; ///< If true, the plugin will read the response to the write operation
-	std::vector<std::uint8_t> rxBuffer; ///< The buffer to store the response in
-};
+	private:
+		const std::vector<std::uint8_t> *txBuffer; ///< The buffer to transmit
+		const bool read; ///< If true, the plugin will read the response to the write operation
+		std::vector<std::uint8_t> rxBuffer; ///< The buffer to store the response in
+	};
+}
 #endif // SPI_TRANSACTION_FRAME_HPP

--- a/hardware_integration/include/isobus/hardware_integration/toucan_vscp_canal.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/toucan_vscp_canal.hpp
@@ -18,53 +18,55 @@
 #include "isobus/isobus/can_frame.hpp"
 #include "isobus/isobus/can_hardware_abstraction.hpp"
 
-//================================================================================================
-/// @class TouCANPlugin
-///
-/// @brief An interface for using a Rusoku TouCAN device via the VSCP CANAL api
-//================================================================================================
-class TouCANPlugin : public CANHardwarePlugin
+namespace isobus
 {
-public:
-	/// @brief Constructor for a TouCAN hardware plugin object
-	/// @param[in] deviceID The id to use for this device
-	/// @param[in] serialNumber The serial number of the CAN adapter to connect with
-	/// @param[in] baudRate The baud rate in thousands (250K baud would mean you need to pass in 250)
-	TouCANPlugin(std::int16_t deviceID, std::uint32_t serialNumber, std::uint16_t baudRate = 250);
+	//================================================================================================
+	/// @class TouCANPlugin
+	///
+	/// @brief An interface for using a Rusoku TouCAN device via the VSCP CANAL api
+	//================================================================================================
+	class TouCANPlugin : public CANHardwarePlugin
+	{
+	public:
+		/// @brief Constructor for a TouCAN hardware plugin object
+		/// @param[in] deviceID The id to use for this device
+		/// @param[in] serialNumber The serial number of the CAN adapter to connect with
+		/// @param[in] baudRate The baud rate in thousands (250K baud would mean you need to pass in 250)
+		TouCANPlugin(std::int16_t deviceID, std::uint32_t serialNumber, std::uint16_t baudRate = 250);
 
-	/// @brief Constructor for a TouCAN hardware plugin object
-	/// @param[in] deviceName The channel to use. This string has a very specific structure that isn't defined anywhere
-	/// except the source code for this specific CANAL implementation.
-	/// @attention Only use this if you know what you are doing, otherwise use the other constructor.
-	explicit TouCANPlugin(std::string deviceName);
+		/// @brief Constructor for a TouCAN hardware plugin object
+		/// @param[in] deviceName The channel to use. This string has a very specific structure that isn't defined anywhere
+		/// except the source code for this specific CANAL implementation.
+		/// @attention Only use this if you know what you are doing, otherwise use the other constructor.
+		explicit TouCANPlugin(std::string deviceName);
 
-	/// @brief The destructor for TouCANPlugin
-	virtual ~TouCANPlugin();
+		/// @brief The destructor for TouCANPlugin
+		virtual ~TouCANPlugin();
 
-	/// @brief Returns if the connection with the hardware is valid
-	/// @returns `true` if connected, `false` if not connected
-	bool get_is_valid() const override;
+		/// @brief Returns if the connection with the hardware is valid
+		/// @returns `true` if connected, `false` if not connected
+		bool get_is_valid() const override;
 
-	/// @brief Closes the connection to the hardware
-	void close() override;
+		/// @brief Closes the connection to the hardware
+		void close() override;
 
-	/// @brief Connects to the hardware
-	void open() override;
+		/// @brief Connects to the hardware
+		void open() override;
 
-	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
-	/// @param[in, out] canFrame The CAN frame that was read
-	/// @returns `true` if a CAN frame was read, otherwise `false`
-	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-	/// @brief Writes a frame to the bus (synchronous)
-	/// @param[in] canFrame The frame to write to the bus
-	/// @returns `true` if the frame was written, otherwise `false`
-	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Writes a frame to the bus (synchronous)
+		/// @param[in] canFrame The frame to write to the bus
+		/// @returns `true` if the frame was written, otherwise `false`
+		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-private:
-	std::string name; ///< A configuration string that is used to connect to the hardware through the CANAL api
-	std::uint32_t handle = 0; ///< The handle that the driver returns to us for the open hardware
-	std::uint32_t openResult = CANAL_ERROR_NOT_OPEN; ///< Stores the result of the call to begin CAN communication. Used for is_valid check later.
-};
-
+	private:
+		std::string name; ///< A configuration string that is used to connect to the hardware through the CANAL api
+		std::uint32_t handle = 0; ///< The handle that the driver returns to us for the open hardware
+		std::uint32_t openResult = CANAL_ERROR_NOT_OPEN; ///< Stores the result of the call to begin CAN communication. Used for is_valid check later.
+	};
+}
 #endif // TOUCAN_VSCP_CANAL_PLUGIN_HPP

--- a/hardware_integration/include/isobus/hardware_integration/twai_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/twai_plugin.hpp
@@ -18,48 +18,50 @@
 
 #include <string>
 
-//================================================================================================
-/// @class TWAIPlugin
-///
-/// @brief A driver for Two-Wire Automotive Interface (TWAI).
-//================================================================================================
-class TWAIPlugin : public CANHardwarePlugin
+namespace isobus
 {
-public:
-	/// @brief Constructor for the socket CAN driver
-	/// @param[in] filterConfig A reference to the filter configuration for the TWAI driver
-	/// @param[in] timingConfig A reference to the timing configuration for the TWAI driver
-	/// @param[in] generalConfig A reference to the general configuration for the TWAI driver
-	explicit TWAIPlugin(const twai_general_config_t *generalConfig, const twai_timing_config_t *timingConfig, const twai_filter_config_t *filterConfig);
+	//================================================================================================
+	/// @class TWAIPlugin
+	///
+	/// @brief A driver for Two-Wire Automotive Interface (TWAI).
+	//================================================================================================
+	class TWAIPlugin : public CANHardwarePlugin
+	{
+	public:
+		/// @brief Constructor for the socket CAN driver
+		/// @param[in] filterConfig A reference to the filter configuration for the TWAI driver
+		/// @param[in] timingConfig A reference to the timing configuration for the TWAI driver
+		/// @param[in] generalConfig A reference to the general configuration for the TWAI driver
+		explicit TWAIPlugin(const twai_general_config_t *generalConfig, const twai_timing_config_t *timingConfig, const twai_filter_config_t *filterConfig);
 
-	/// @brief The destructor for TWAIPlugin
-	virtual ~TWAIPlugin();
+		/// @brief The destructor for TWAIPlugin
+		virtual ~TWAIPlugin();
 
-	/// @brief Returns if the socket connection is valid
-	/// @returns `true` if connected, `false` if not connected
-	bool get_is_valid() const override;
+		/// @brief Returns if the socket connection is valid
+		/// @returns `true` if connected, `false` if not connected
+		bool get_is_valid() const override;
 
-	/// @brief Closes the socket
-	void close() override;
+		/// @brief Closes the socket
+		void close() override;
 
-	/// @brief Connects to the socket
-	void open() override;
+		/// @brief Connects to the socket
+		void open() override;
 
-	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
-	/// @param[in, out] canFrame The CAN frame that was read
-	/// @returns `true` if a CAN frame was read, otherwise `false`
-	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-	/// @brief Writes a frame to the bus (synchronous)
-	/// @param[in] canFrame The frame to write to the bus
-	/// @returns `true` if the frame was written, otherwise `false`
-	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+		/// @brief Writes a frame to the bus (synchronous)
+		/// @param[in] canFrame The frame to write to the bus
+		/// @returns `true` if the frame was written, otherwise `false`
+		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
 
-private:
-	const twai_general_config_t *generalConfig;
-	const twai_timing_config_t *timingConfig;
-	const twai_filter_config_t *filterConfig;
-};
-
+	private:
+		const twai_general_config_t *generalConfig;
+		const twai_timing_config_t *timingConfig;
+		const twai_filter_config_t *filterConfig;
+	};
+}
 #endif // ESP_PLATFORM
 #endif // TWAI_PLUGIN_HPP

--- a/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
@@ -22,75 +22,77 @@
 #include <string>
 #include <vector>
 
-//================================================================================================
-/// @class VirtualCANPlugin
-///
-/// @brief An OS and hardware independent virtual CAN interface driver for testing purposes.
-/// @details Any instance connecting to the same channel and in the same process can communicate.
-/// However, this plugin does not implement rate limiting or any other CAN bus specific features,
-/// like prioritization under heavy load.
-//================================================================================================
-class VirtualCANPlugin : public CANHardwarePlugin
+namespace isobus
 {
-public:
-	/// @brief Constructor for the virtual CAN driver
-	/// @param[in] channel The virtual channel name to use. Free to choose.
-	/// @param[in] receiveOwnMessages If `true`, the driver will receive its own messages.
-	VirtualCANPlugin(const std::string channel = "", const bool receiveOwnMessages = false);
-
-	/// @brief Destructor for the virtual CAN driver
-	virtual ~VirtualCANPlugin();
-
-	/// @brief Returns if the socket connection is valid
-	/// @returns `true` if connected, `false` if not connected
-	bool get_is_valid() const override;
-
-	/// @brief Returns the assigned virtual channel name
-	/// @returns The virtual channel name the bus is assigned to
-	std::string get_channel_name() const;
-
-	/// @brief Closes the socket
-	void close() override;
-
-	/// @brief Connects to the socket
-	void open() override;
-
-	/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
-	/// @param[in, out] canFrame The CAN frame that was read
-	/// @returns `true` if a CAN frame was read, otherwise `false`
-	bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
-
-	/// @brief Writes a frame to the bus (synchronous)
-	/// @param[in] canFrame The frame to write to the bus
-	/// @returns `true` if the frame was written, otherwise `false`
-	bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
-
-	/// @brief Allows us to write messages as if we received them from the bus
-	/// @param[in] canFrame The frame to write to the bus
-	void write_frame_as_if_received(const isobus::HardwareInterfaceCANFrame &canFrame) const;
-
-	/// @brief Returns if the internal message queue is empty or not
-	/// @returns `true` if the internal message queue is empty, otherwise false
-	bool get_queue_empty() const;
-
-private:
-	/// @brief A struct holding information about a virtual CAN device
-	struct VirtualDevice
+	//================================================================================================
+	/// @class VirtualCANPlugin
+	///
+	/// @brief An OS and hardware independent virtual CAN interface driver for testing purposes.
+	/// @details Any instance connecting to the same channel and in the same process can communicate.
+	/// However, this plugin does not implement rate limiting or any other CAN bus specific features,
+	/// like prioritization under heavy load.
+	//================================================================================================
+	class VirtualCANPlugin : public CANHardwarePlugin
 	{
-		std::deque<isobus::HardwareInterfaceCANFrame> queue; ///< A queue of CAN frames
-		std::condition_variable condition; ///< A condition variable to wake us up when a frame is received
+	public:
+		/// @brief Constructor for the virtual CAN driver
+		/// @param[in] channel The virtual channel name to use. Free to choose.
+		/// @param[in] receiveOwnMessages If `true`, the driver will receive its own messages.
+		VirtualCANPlugin(const std::string channel = "", const bool receiveOwnMessages = false);
+
+		/// @brief Destructor for the virtual CAN driver
+		virtual ~VirtualCANPlugin();
+
+		/// @brief Returns if the socket connection is valid
+		/// @returns `true` if connected, `false` if not connected
+		bool get_is_valid() const override;
+
+		/// @brief Returns the assigned virtual channel name
+		/// @returns The virtual channel name the bus is assigned to
+		std::string get_channel_name() const;
+
+		/// @brief Closes the socket
+		void close() override;
+
+		/// @brief Connects to the socket
+		void open() override;
+
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		bool read_frame(isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+		/// @brief Writes a frame to the bus (synchronous)
+		/// @param[in] canFrame The frame to write to the bus
+		/// @returns `true` if the frame was written, otherwise `false`
+		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame) override;
+
+		/// @brief Allows us to write messages as if we received them from the bus
+		/// @param[in] canFrame The frame to write to the bus
+		void write_frame_as_if_received(const isobus::HardwareInterfaceCANFrame &canFrame) const;
+
+		/// @brief Returns if the internal message queue is empty or not
+		/// @returns `true` if the internal message queue is empty, otherwise false
+		bool get_queue_empty() const;
+
+	private:
+		/// @brief A struct holding information about a virtual CAN device
+		struct VirtualDevice
+		{
+			std::deque<isobus::HardwareInterfaceCANFrame> queue; ///< A queue of CAN frames
+			std::condition_variable condition; ///< A condition variable to wake us up when a frame is received
+		};
+
+		static constexpr size_t MAX_QUEUE_SIZE = 1000; ///< The maximum size of the queue, mostly arbitrary
+
+		static std::mutex mutex; ///< Mutex to access channels and queues for thread safety
+		static std::map<std::string, std::vector<std::shared_ptr<VirtualDevice>>> channels; ///< A channel is a vector of devices
+
+		const std::string channel; ///< The virtual channel name
+		const bool receiveOwnMessages; ///< If `true`, the driver will receive its own messages
+
+		std::shared_ptr<VirtualDevice> ourDevice; ///< A pointer to the virtual device of this instance
+		std::atomic_bool running; ///< If `true`, the driver is running
 	};
-
-	static constexpr size_t MAX_QUEUE_SIZE = 1000; ///< The maximum size of the queue, mostly arbitrary
-
-	static std::mutex mutex; ///< Mutex to access channels and queues for thread safety
-	static std::map<std::string, std::vector<std::shared_ptr<VirtualDevice>>> channels; ///< A channel is a vector of devices
-
-	const std::string channel; ///< The virtual channel name
-	const bool receiveOwnMessages; ///< If `true`, the driver will receive its own messages
-
-	std::shared_ptr<VirtualDevice> ourDevice; ///< A pointer to the virtual device of this instance
-	std::atomic_bool running; ///< If `true`, the driver is running
-};
-
+}
 #endif // VIRTUAL_CAN_PLUGIN_HPP

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -14,385 +14,388 @@
 
 #include <algorithm>
 
-std::unique_ptr<std::thread> CANHardwareInterface::updateThread;
-std::unique_ptr<std::thread> CANHardwareInterface::wakeupThread;
-std::condition_variable CANHardwareInterface::updateThreadWakeupCondition;
-std::atomic_bool CANHardwareInterface::stackNeedsUpdate = { false };
-std::uint32_t CANHardwareInterface::periodicUpdateInterval = PERIODIC_UPDATE_INTERVAL;
-
-isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> CANHardwareInterface::frameReceivedEventDispatcher;
-isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> CANHardwareInterface::frameTransmittedEventDispatcher;
-isobus::EventDispatcher<> CANHardwareInterface::periodicUpdateEventDispatcher;
-
-std::vector<std::unique_ptr<CANHardwareInterface::CANHardware>> CANHardwareInterface::hardwareChannels;
-std::mutex CANHardwareInterface::hardwareChannelsMutex;
-std::mutex CANHardwareInterface::updateMutex;
-std::atomic_bool CANHardwareInterface::threadsStarted = { false };
-
-CANHardwareInterface CANHardwareInterface::SINGLETON;
-
-CANHardwareInterface::~CANHardwareInterface()
+namespace isobus
 {
-	stop_threads();
-}
+	std::unique_ptr<std::thread> CANHardwareInterface::updateThread;
+	std::unique_ptr<std::thread> CANHardwareInterface::wakeupThread;
+	std::condition_variable CANHardwareInterface::updateThreadWakeupCondition;
+	std::atomic_bool CANHardwareInterface::stackNeedsUpdate = { false };
+	std::uint32_t CANHardwareInterface::periodicUpdateInterval = PERIODIC_UPDATE_INTERVAL;
 
-bool isobus::send_can_message_frame_to_hardware(const isobus::HardwareInterfaceCANFrame &frame)
-{
-	return CANHardwareInterface::transmit_can_message(frame);
-}
+	isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> CANHardwareInterface::frameReceivedEventDispatcher;
+	isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> CANHardwareInterface::frameTransmittedEventDispatcher;
+	isobus::EventDispatcher<> CANHardwareInterface::periodicUpdateEventDispatcher;
 
-bool CANHardwareInterface::set_number_of_can_channels(uint8_t value)
-{
-	std::lock_guard<std::mutex> lock(hardwareChannelsMutex);
+	std::vector<std::unique_ptr<CANHardwareInterface::CANHardware>> CANHardwareInterface::hardwareChannels;
+	std::mutex CANHardwareInterface::hardwareChannelsMutex;
+	std::mutex CANHardwareInterface::updateMutex;
+	std::atomic_bool CANHardwareInterface::threadsStarted = { false };
 
-	if (threadsStarted)
+	CANHardwareInterface CANHardwareInterface::SINGLETON;
+
+	CANHardwareInterface::~CANHardwareInterface()
 	{
-		isobus::CANStackLogger::error("[HardwareInterface] Cannot set number of channels after interface is started.");
-		return false;
+		stop_threads();
 	}
 
-	while (value > hardwareChannels.size())
+	bool send_can_message_frame_to_hardware(const HardwareInterfaceCANFrame &frame)
 	{
-		hardwareChannels.push_back(std::make_unique<CANHardware>());
-		hardwareChannels.back()->receiveMessageThread = nullptr;
-		hardwareChannels.back()->frameHandler = nullptr;
-	}
-	while (value < hardwareChannels.size())
-	{
-		hardwareChannels.pop_back();
-	}
-	return true;
-}
-
-bool CANHardwareInterface::assign_can_channel_frame_handler(std::uint8_t channelIndex, std::shared_ptr<CANHardwarePlugin> driver)
-{
-	std::lock_guard<std::mutex> lock(hardwareChannelsMutex);
-
-	if (threadsStarted)
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Cannot assign frame handlers after interface is started.");
-		return false;
+		return CANHardwareInterface::transmit_can_message(frame);
 	}
 
-	if (channelIndex >= hardwareChannels.size())
+	bool CANHardwareInterface::set_number_of_can_channels(uint8_t value)
 	{
-		isobus::CANStackLogger::error("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) +
-		                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set. " +
-		                              "Use set_number_of_can_channels() to increase the number of channels before assigning frame handlers.");
-		return false;
-	}
-
-	if (nullptr != hardwareChannels[channelIndex]->frameHandler)
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) + ", because it is already assigned.");
-		return false;
-	}
-
-	hardwareChannels[channelIndex]->frameHandler = driver;
-	return true;
-}
-
-std::uint8_t CANHardwareInterface::get_number_of_can_channels()
-{
-	return static_cast<std::uint8_t>(hardwareChannels.size() & std::numeric_limits<std::uint8_t>::max());
-}
-
-bool CANHardwareInterface::unassign_can_channel_frame_handler(std::uint8_t channelIndex)
-{
-	std::lock_guard<std::mutex> lock(hardwareChannelsMutex);
-
-	if (threadsStarted)
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Cannot remove frame handlers after interface is started.");
-		return false;
-	}
-
-	if (channelIndex >= hardwareChannels.size())
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) +
-		                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
-		return false;
-	}
-
-	if (nullptr == hardwareChannels[channelIndex]->frameHandler)
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) + ", because it is not assigned.");
-		return false;
-	}
-
-	hardwareChannels[channelIndex]->frameHandler = nullptr;
-	return true;
-}
-
-bool CANHardwareInterface::start()
-{
-	std::lock_guard<std::mutex> lock(hardwareChannelsMutex);
-
-	if (threadsStarted)
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Cannot start interface more than once.");
-		return false;
-	}
-
-	updateThread = std::make_unique<std::thread>(update_thread_function);
-	wakeupThread = std::make_unique<std::thread>(periodic_update_function);
-
-	threadsStarted = true;
-
-	for (std::size_t i = 0; i < hardwareChannels.size(); i++)
-	{
-		if (nullptr != hardwareChannels[i]->frameHandler)
-		{
-			hardwareChannels[i]->frameHandler->open();
-
-			if (hardwareChannels[i]->frameHandler->get_is_valid())
-			{
-				hardwareChannels[i]->receiveMessageThread = std::make_unique<std::thread>(receive_message_thread_function, static_cast<std::uint8_t>(i));
-			}
-		}
-	}
-
-	return true;
-}
-
-bool CANHardwareInterface::stop()
-{
-	if (!threadsStarted)
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Cannot stop interface before it is started.");
-		return false;
-	}
-	stop_threads();
-
-	std::lock_guard<std::mutex> channelsLock(hardwareChannelsMutex);
-	std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
-		if (nullptr != channel->frameHandler)
-		{
-			channel->frameHandler = nullptr;
-		}
-		std::unique_lock<std::mutex> transmittingLock(channel->messagesToBeTransmittedMutex);
-		channel->messagesToBeTransmitted.clear();
-		transmittingLock.unlock();
-
-		std::unique_lock<std::mutex> receivingLock(channel->receivedMessagesMutex);
-		channel->receivedMessages.clear();
-		receivingLock.unlock();
-	});
-	return true;
-}
-bool CANHardwareInterface::is_running()
-{
-	return threadsStarted;
-}
-
-bool CANHardwareInterface::transmit_can_message(const isobus::HardwareInterfaceCANFrame &packet)
-{
-	if (!threadsStarted)
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message before interface is started.");
-		return false;
-	}
-
-	if (packet.channel >= hardwareChannels.size())
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message on channel " + isobus::to_string(packet.channel) +
-		                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
-		return false;
-	}
-
-	const std::unique_ptr<CANHardware> &channel = hardwareChannels[packet.channel];
-	if (nullptr == channel->frameHandler)
-	{
-		isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message on channel " + isobus::to_string(packet.channel) + ", because it is not assigned.");
-		return false;
-	}
-
-	if (channel->frameHandler->get_is_valid())
-	{
-		std::lock_guard<std::mutex> lock(channel->messagesToBeTransmittedMutex);
-		channel->messagesToBeTransmitted.push_back(packet);
-
-		updateThreadWakeupCondition.notify_all();
-		return true;
-	}
-	return false;
-}
-
-isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> &CANHardwareInterface::get_can_frame_received_event_dispatcher()
-{
-	return frameReceivedEventDispatcher;
-}
-
-isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> &CANHardwareInterface::get_can_frame_transmitted_event_dispatcher()
-{
-	return frameTransmittedEventDispatcher;
-}
-
-isobus::EventDispatcher<> &CANHardwareInterface::get_periodic_update_event_dispatcher()
-{
-	return periodicUpdateEventDispatcher;
-}
-
-void CANHardwareInterface::set_periodic_update_interval(std::uint32_t value)
-{
-	periodicUpdateInterval = value;
-}
-
-std::uint32_t CANHardwareInterface::get_periodic_update_interval()
-{
-	return periodicUpdateInterval;
-}
-
-void CANHardwareInterface::update_thread_function()
-{
-	std::unique_lock<std::mutex> channelsLock(hardwareChannelsMutex);
-	// Wait until everything is running
-	channelsLock.unlock();
-
-	while (threadsStarted)
-	{
-		std::unique_lock<std::mutex> threadLock(updateMutex);
-		updateThreadWakeupCondition.wait_for(threadLock, std::chrono::seconds(1)); // Timeout after 1 second
+		std::lock_guard<std::mutex> lock(hardwareChannelsMutex);
 
 		if (threadsStarted)
 		{
-			// Stage 1 - Receiving messages from hardware
-			channelsLock.lock();
-			std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
-				std::lock_guard<std::mutex> lock(channel->receivedMessagesMutex);
-				while (!channel->receivedMessages.empty())
-				{
-					auto &frame = channel->receivedMessages.front();
+			isobus::CANStackLogger::error("[HardwareInterface] Cannot set number of channels after interface is started.");
+			return false;
+		}
 
-					frameReceivedEventDispatcher.invoke(std::move(frame));
-					isobus::receive_can_message_frame_from_hardware(frame);
+		while (value > hardwareChannels.size())
+		{
+			hardwareChannels.push_back(std::make_unique<CANHardware>());
+			hardwareChannels.back()->receiveMessageThread = nullptr;
+			hardwareChannels.back()->frameHandler = nullptr;
+		}
+		while (value < hardwareChannels.size())
+		{
+			hardwareChannels.pop_back();
+		}
+		return true;
+	}
 
-					channel->receivedMessages.pop_front();
-				}
-			});
-			channelsLock.unlock();
+	bool CANHardwareInterface::assign_can_channel_frame_handler(std::uint8_t channelIndex, std::shared_ptr<CANHardwarePlugin> driver)
+	{
+		std::lock_guard<std::mutex> lock(hardwareChannelsMutex);
 
-			// Stage 2 - Sending messages
-			if (stackNeedsUpdate)
+		if (threadsStarted)
+		{
+			isobus::CANStackLogger::error("[HardwareInterface] Cannot assign frame handlers after interface is started.");
+			return false;
+		}
+
+		if (channelIndex >= hardwareChannels.size())
+		{
+			isobus::CANStackLogger::error("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) +
+			                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set. " +
+			                              "Use set_number_of_can_channels() to increase the number of channels before assigning frame handlers.");
+			return false;
+		}
+
+		if (nullptr != hardwareChannels[channelIndex]->frameHandler)
+		{
+			isobus::CANStackLogger::error("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) + ", because it is already assigned.");
+			return false;
+		}
+
+		hardwareChannels[channelIndex]->frameHandler = driver;
+		return true;
+	}
+
+	std::uint8_t CANHardwareInterface::get_number_of_can_channels()
+	{
+		return static_cast<std::uint8_t>(hardwareChannels.size() & std::numeric_limits<std::uint8_t>::max());
+	}
+
+	bool CANHardwareInterface::unassign_can_channel_frame_handler(std::uint8_t channelIndex)
+	{
+		std::lock_guard<std::mutex> lock(hardwareChannelsMutex);
+
+		if (threadsStarted)
+		{
+			isobus::CANStackLogger::error("[HardwareInterface] Cannot remove frame handlers after interface is started.");
+			return false;
+		}
+
+		if (channelIndex >= hardwareChannels.size())
+		{
+			isobus::CANStackLogger::error("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) +
+			                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
+			return false;
+		}
+
+		if (nullptr == hardwareChannels[channelIndex]->frameHandler)
+		{
+			isobus::CANStackLogger::error("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) + ", because it is not assigned.");
+			return false;
+		}
+
+		hardwareChannels[channelIndex]->frameHandler = nullptr;
+		return true;
+	}
+
+	bool CANHardwareInterface::start()
+	{
+		std::lock_guard<std::mutex> lock(hardwareChannelsMutex);
+
+		if (threadsStarted)
+		{
+			isobus::CANStackLogger::error("[HardwareInterface] Cannot start interface more than once.");
+			return false;
+		}
+
+		updateThread = std::make_unique<std::thread>(update_thread_function);
+		wakeupThread = std::make_unique<std::thread>(periodic_update_function);
+
+		threadsStarted = true;
+
+		for (std::size_t i = 0; i < hardwareChannels.size(); i++)
+		{
+			if (nullptr != hardwareChannels[i]->frameHandler)
 			{
-				stackNeedsUpdate = false;
-				periodicUpdateEventDispatcher.invoke();
-				isobus::periodic_update_from_hardware();
-			}
+				hardwareChannels[i]->frameHandler->open();
 
-			// Stage 3 - Transmitting messages to hardware
-			channelsLock.lock();
-			std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
-				std::lock_guard<std::mutex> lock(channel->messagesToBeTransmittedMutex);
-				while (!channel->messagesToBeTransmitted.empty())
+				if (hardwareChannels[i]->frameHandler->get_is_valid())
 				{
-					auto &frame = channel->messagesToBeTransmitted.front();
-
-					if (transmit_can_message_from_buffer(frame))
-					{
-						frameTransmittedEventDispatcher.invoke(std::move(frame));
-						channel->messagesToBeTransmitted.pop_front();
-					}
-					else
-					{
-						break;
-					}
+					hardwareChannels[i]->receiveMessageThread = std::make_unique<std::thread>(receive_message_thread_function, static_cast<std::uint8_t>(i));
 				}
-			});
-			channelsLock.unlock();
-		}
-	}
-}
-
-void CANHardwareInterface::receive_message_thread_function(std::uint8_t channelIndex)
-{
-	std::unique_lock<std::mutex> channelsLock(hardwareChannelsMutex);
-	// Wait until everything is running
-	channelsLock.unlock();
-
-	isobus::HardwareInterfaceCANFrame frame;
-	while ((threadsStarted) &&
-	       (nullptr != hardwareChannels[channelIndex]->frameHandler))
-	{
-		if (hardwareChannels[channelIndex]->frameHandler->get_is_valid())
-		{
-			// Socket or other hardware still open
-			if (hardwareChannels[channelIndex]->frameHandler->read_frame(frame))
-			{
-				frame.channel = channelIndex;
-				std::unique_lock<std::mutex> receiveLock(hardwareChannels[channelIndex]->receivedMessagesMutex);
-				hardwareChannels[channelIndex]->receivedMessages.push_back(frame);
-				receiveLock.unlock();
-				updateThreadWakeupCondition.notify_all();
 			}
 		}
-		else
+
+		return true;
+	}
+
+	bool CANHardwareInterface::stop()
+	{
+		if (!threadsStarted)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
-			std::this_thread::sleep_for(std::chrono::milliseconds(1000)); // Arbitrary, but don't want to infinite loop on the validity check.
+			isobus::CANStackLogger::error("[HardwareInterface] Cannot stop interface before it is started.");
+			return false;
 		}
+		stop_threads();
+
+		std::lock_guard<std::mutex> channelsLock(hardwareChannelsMutex);
+		std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
+			if (nullptr != channel->frameHandler)
+			{
+				channel->frameHandler = nullptr;
+			}
+			std::unique_lock<std::mutex> transmittingLock(channel->messagesToBeTransmittedMutex);
+			channel->messagesToBeTransmitted.clear();
+			transmittingLock.unlock();
+
+			std::unique_lock<std::mutex> receivingLock(channel->receivedMessagesMutex);
+			channel->receivedMessages.clear();
+			receivingLock.unlock();
+		});
+		return true;
 	}
-}
-
-bool CANHardwareInterface::transmit_can_message_from_buffer(isobus::HardwareInterfaceCANFrame &packet)
-{
-	bool retVal = false;
-	if (packet.channel < hardwareChannels.size())
+	bool CANHardwareInterface::is_running()
 	{
-		retVal = ((nullptr != hardwareChannels[packet.channel]->frameHandler) &&
-		          (hardwareChannels[packet.channel]->frameHandler->write_frame(packet)));
+		return threadsStarted;
 	}
-	return retVal;
-}
 
-void CANHardwareInterface::periodic_update_function()
-{
-	std::unique_lock<std::mutex> channelsLock(hardwareChannelsMutex);
-	// Wait until everything is running
-	channelsLock.unlock();
-
-	while (threadsStarted)
+	bool CANHardwareInterface::transmit_can_message(const isobus::HardwareInterfaceCANFrame &packet)
 	{
-		stackNeedsUpdate = true;
-		updateThreadWakeupCondition.notify_all();
-		std::this_thread::sleep_for(std::chrono::milliseconds(periodicUpdateInterval));
-	}
-}
-
-void CANHardwareInterface::stop_threads()
-{
-	threadsStarted = false;
-	if (nullptr != updateThread)
-	{
-		if (updateThread->joinable())
+		if (!threadsStarted)
 		{
+			isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message before interface is started.");
+			return false;
+		}
+
+		if (packet.channel >= hardwareChannels.size())
+		{
+			isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message on channel " + isobus::to_string(packet.channel) +
+			                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
+			return false;
+		}
+
+		const std::unique_ptr<CANHardware> &channel = hardwareChannels[packet.channel];
+		if (nullptr == channel->frameHandler)
+		{
+			isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message on channel " + isobus::to_string(packet.channel) + ", because it is not assigned.");
+			return false;
+		}
+
+		if (channel->frameHandler->get_is_valid())
+		{
+			std::lock_guard<std::mutex> lock(channel->messagesToBeTransmittedMutex);
+			channel->messagesToBeTransmitted.push_back(packet);
+
 			updateThreadWakeupCondition.notify_all();
-			updateThread->join();
+			return true;
 		}
-		updateThread = nullptr;
+		return false;
 	}
 
-	if (nullptr != wakeupThread)
+	isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> &CANHardwareInterface::get_can_frame_received_event_dispatcher()
 	{
-		if (wakeupThread->joinable())
-		{
-			wakeupThread->join();
-		}
-		wakeupThread = nullptr;
+		return frameReceivedEventDispatcher;
 	}
 
-	std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
-		if (nullptr != channel->frameHandler)
+	isobus::EventDispatcher<isobus::HardwareInterfaceCANFrame> &CANHardwareInterface::get_can_frame_transmitted_event_dispatcher()
+	{
+		return frameTransmittedEventDispatcher;
+	}
+
+	isobus::EventDispatcher<> &CANHardwareInterface::get_periodic_update_event_dispatcher()
+	{
+		return periodicUpdateEventDispatcher;
+	}
+
+	void CANHardwareInterface::set_periodic_update_interval(std::uint32_t value)
+	{
+		periodicUpdateInterval = value;
+	}
+
+	std::uint32_t CANHardwareInterface::get_periodic_update_interval()
+	{
+		return periodicUpdateInterval;
+	}
+
+	void CANHardwareInterface::update_thread_function()
+	{
+		std::unique_lock<std::mutex> channelsLock(hardwareChannelsMutex);
+		// Wait until everything is running
+		channelsLock.unlock();
+
+		while (threadsStarted)
 		{
-			channel->frameHandler->close();
-		}
-		if (nullptr != channel->receiveMessageThread)
-		{
-			if (channel->receiveMessageThread->joinable())
+			std::unique_lock<std::mutex> threadLock(updateMutex);
+			updateThreadWakeupCondition.wait_for(threadLock, std::chrono::seconds(1)); // Timeout after 1 second
+
+			if (threadsStarted)
 			{
-				channel->receiveMessageThread->join();
+				// Stage 1 - Receiving messages from hardware
+				channelsLock.lock();
+				std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
+					std::lock_guard<std::mutex> lock(channel->receivedMessagesMutex);
+					while (!channel->receivedMessages.empty())
+					{
+						auto &frame = channel->receivedMessages.front();
+
+						frameReceivedEventDispatcher.invoke(std::move(frame));
+						isobus::receive_can_message_frame_from_hardware(frame);
+
+						channel->receivedMessages.pop_front();
+					}
+				});
+				channelsLock.unlock();
+
+				// Stage 2 - Sending messages
+				if (stackNeedsUpdate)
+				{
+					stackNeedsUpdate = false;
+					periodicUpdateEventDispatcher.invoke();
+					isobus::periodic_update_from_hardware();
+				}
+
+				// Stage 3 - Transmitting messages to hardware
+				channelsLock.lock();
+				std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
+					std::lock_guard<std::mutex> lock(channel->messagesToBeTransmittedMutex);
+					while (!channel->messagesToBeTransmitted.empty())
+					{
+						auto &frame = channel->messagesToBeTransmitted.front();
+
+						if (transmit_can_message_from_buffer(frame))
+						{
+							frameTransmittedEventDispatcher.invoke(std::move(frame));
+							channel->messagesToBeTransmitted.pop_front();
+						}
+						else
+						{
+							break;
+						}
+					}
+				});
+				channelsLock.unlock();
 			}
-			channel->receiveMessageThread = nullptr;
 		}
-	});
+	}
+
+	void CANHardwareInterface::receive_message_thread_function(std::uint8_t channelIndex)
+	{
+		std::unique_lock<std::mutex> channelsLock(hardwareChannelsMutex);
+		// Wait until everything is running
+		channelsLock.unlock();
+
+		isobus::HardwareInterfaceCANFrame frame;
+		while ((threadsStarted) &&
+		       (nullptr != hardwareChannels[channelIndex]->frameHandler))
+		{
+			if (hardwareChannels[channelIndex]->frameHandler->get_is_valid())
+			{
+				// Socket or other hardware still open
+				if (hardwareChannels[channelIndex]->frameHandler->read_frame(frame))
+				{
+					frame.channel = channelIndex;
+					std::unique_lock<std::mutex> receiveLock(hardwareChannels[channelIndex]->receivedMessagesMutex);
+					hardwareChannels[channelIndex]->receivedMessages.push_back(frame);
+					receiveLock.unlock();
+					updateThreadWakeupCondition.notify_all();
+				}
+			}
+			else
+			{
+				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
+				std::this_thread::sleep_for(std::chrono::milliseconds(1000)); // Arbitrary, but don't want to infinite loop on the validity check.
+			}
+		}
+	}
+
+	bool CANHardwareInterface::transmit_can_message_from_buffer(isobus::HardwareInterfaceCANFrame &packet)
+	{
+		bool retVal = false;
+		if (packet.channel < hardwareChannels.size())
+		{
+			retVal = ((nullptr != hardwareChannels[packet.channel]->frameHandler) &&
+			          (hardwareChannels[packet.channel]->frameHandler->write_frame(packet)));
+		}
+		return retVal;
+	}
+
+	void CANHardwareInterface::periodic_update_function()
+	{
+		std::unique_lock<std::mutex> channelsLock(hardwareChannelsMutex);
+		// Wait until everything is running
+		channelsLock.unlock();
+
+		while (threadsStarted)
+		{
+			stackNeedsUpdate = true;
+			updateThreadWakeupCondition.notify_all();
+			std::this_thread::sleep_for(std::chrono::milliseconds(periodicUpdateInterval));
+		}
+	}
+
+	void CANHardwareInterface::stop_threads()
+	{
+		threadsStarted = false;
+		if (nullptr != updateThread)
+		{
+			if (updateThread->joinable())
+			{
+				updateThreadWakeupCondition.notify_all();
+				updateThread->join();
+			}
+			updateThread = nullptr;
+		}
+
+		if (nullptr != wakeupThread)
+		{
+			if (wakeupThread->joinable())
+			{
+				wakeupThread->join();
+			}
+			wakeupThread = nullptr;
+		}
+
+		std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
+			if (nullptr != channel->frameHandler)
+			{
+				channel->frameHandler->close();
+			}
+			if (nullptr != channel->receiveMessageThread)
+			{
+				if (channel->receiveMessageThread->joinable())
+				{
+					channel->receiveMessageThread->join();
+				}
+				channel->receiveMessageThread = nullptr;
+			}
+		});
+	}
 }

--- a/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
+++ b/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
@@ -17,322 +17,325 @@
 
 #include <thread>
 
-std::unique_ptr<InnoMakerUsb2CanLib> InnoMakerUSB2CANWindowsPlugin::driverInstance = nullptr;
-
-InnoMakerUSB2CANWindowsPlugin::InnoMakerUSB2CANWindowsPlugin(int channel, Baudrate baudrate) :
-  channel(channel),
-  baudrate(baudrate)
+namespace isobus
 {
-	if (nullptr == driverInstance)
+	std::unique_ptr<InnoMakerUsb2CanLib> InnoMakerUSB2CANWindowsPlugin::driverInstance = nullptr;
+
+	InnoMakerUSB2CANWindowsPlugin::InnoMakerUSB2CANWindowsPlugin(int channel, Baudrate baudrate) :
+	  channel(channel),
+	  baudrate(baudrate)
 	{
-		driverInstance = std::unique_ptr<InnoMakerUsb2CanLib>(new InnoMakerUsb2CanLib());
-		driverInstance->setup();
-		driverInstance->scanInnoMakerDevice();
-	}
-	txContexts = std::unique_ptr<InnoMakerUsb2CanLib::innomaker_can>(new InnoMakerUsb2CanLib::innomaker_can());
-}
-
-InnoMakerUSB2CANWindowsPlugin::~InnoMakerUSB2CANWindowsPlugin()
-{
-	close();
-}
-
-bool InnoMakerUSB2CANWindowsPlugin::get_is_valid() const
-{
-	return nullptr != driverInstance->getInnoMakerDevice(channel) && driverInstance->getInnoMakerDevice(channel)->isOpen;
-}
-
-void InnoMakerUSB2CANWindowsPlugin::close()
-{
-	InnoMakerUsb2CanLib::InnoMakerDevice *device = driverInstance->getInnoMakerDevice(channel);
-
-	if (nullptr != device && device->isOpen)
-	{
-		driverInstance->urbResetDevice(device);
-		driverInstance->closeInnoMakerDevice(device);
-
-		// Check if all channels are closed and if so, close the driver instance
-		bool allChannelsClosed = true;
-		for (int i = 0; i < driverInstance->getInnoMakerDeviceCount(); i++)
+		if (nullptr == driverInstance)
 		{
-			if (nullptr != driverInstance->getInnoMakerDevice(i) &&
-			    driverInstance->getInnoMakerDevice(i)->isOpen)
+			driverInstance = std::unique_ptr<InnoMakerUsb2CanLib>(new InnoMakerUsb2CanLib());
+			driverInstance->setup();
+			driverInstance->scanInnoMakerDevice();
+		}
+		txContexts = std::unique_ptr<InnoMakerUsb2CanLib::innomaker_can>(new InnoMakerUsb2CanLib::innomaker_can());
+	}
+
+	InnoMakerUSB2CANWindowsPlugin::~InnoMakerUSB2CANWindowsPlugin()
+	{
+		close();
+	}
+
+	bool InnoMakerUSB2CANWindowsPlugin::get_is_valid() const
+	{
+		return nullptr != driverInstance->getInnoMakerDevice(channel) && driverInstance->getInnoMakerDevice(channel)->isOpen;
+	}
+
+	void InnoMakerUSB2CANWindowsPlugin::close()
+	{
+		InnoMakerUsb2CanLib::InnoMakerDevice *device = driverInstance->getInnoMakerDevice(channel);
+
+		if (nullptr != device && device->isOpen)
+		{
+			driverInstance->urbResetDevice(device);
+			driverInstance->closeInnoMakerDevice(device);
+
+			// Check if all channels are closed and if so, close the driver instance
+			bool allChannelsClosed = true;
+			for (int i = 0; i < driverInstance->getInnoMakerDeviceCount(); i++)
 			{
-				allChannelsClosed = false;
+				if (nullptr != driverInstance->getInnoMakerDevice(i) &&
+				    driverInstance->getInnoMakerDevice(i)->isOpen)
+				{
+					allChannelsClosed = false;
+					break;
+				}
+			}
+			if (allChannelsClosed)
+			{
+				isobus::CANStackLogger::info("[InnoMaker-Windows] All channels closed, closing driver instance");
+				driverInstance->setdown();
+				driverInstance = nullptr;
+			}
+		}
+	}
+
+	void InnoMakerUSB2CANWindowsPlugin::open()
+	{
+		InnoMakerUsb2CanLib::InnoMakerDevice *device = driverInstance->getInnoMakerDevice(channel);
+
+		if (nullptr != device)
+		{
+			driverInstance->urbResetDevice(device);
+			driverInstance->closeInnoMakerDevice(device);
+
+			// Reset tx buffer according to the documentation
+			for (int i = 0; i < driverInstance->innomaker_MAX_TX_URBS; i++)
+			{
+				txContexts->tx_context[i].echo_id = driverInstance->innomaker_MAX_TX_URBS;
+			}
+
+			InnoMakerUsb2CanLib::Innomaker_device_bittming bitTiming;
+			switch (baudrate)
+			{
+				case B20k:
+				{
+					bitTiming.prop_seg = 6;
+					bitTiming.phase_seg1 = 7;
+					bitTiming.phase_seg2 = 2;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 150;
+				}
+				break;
+				case B33k3:
+				{
+					bitTiming.prop_seg = 3;
+					bitTiming.phase_seg1 = 3;
+					bitTiming.phase_seg2 = 1;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 180;
+				}
+				break;
+				case B40k:
+				{
+					bitTiming.prop_seg = 6;
+					bitTiming.phase_seg1 = 7;
+					bitTiming.phase_seg2 = 2;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 75;
+				}
+				break;
+				case B50k:
+				{
+					bitTiming.prop_seg = 6;
+					bitTiming.phase_seg1 = 7;
+					bitTiming.phase_seg2 = 2;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 60;
+				}
+				break;
+				case B66k6:
+				{
+					bitTiming.prop_seg = 3;
+					bitTiming.phase_seg1 = 3;
+					bitTiming.phase_seg2 = 1;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 90;
+				}
+				break;
+				case B80k:
+				{
+					bitTiming.prop_seg = 3;
+					bitTiming.phase_seg1 = 3;
+					bitTiming.phase_seg2 = 1;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 75;
+				}
+				break;
+				case B83k3:
+				{
+					bitTiming.prop_seg = 3;
+					bitTiming.phase_seg1 = 3;
+					bitTiming.phase_seg2 = 1;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 72;
+				}
+				break;
+				case B100k:
+				{
+					bitTiming.prop_seg = 6;
+					bitTiming.phase_seg1 = 7;
+					bitTiming.phase_seg2 = 2;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 30;
+				}
+				break;
+				case B125k:
+				{
+					bitTiming.prop_seg = 6;
+					bitTiming.phase_seg1 = 7;
+					bitTiming.phase_seg2 = 2;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 24;
+				}
+				break;
+				case B200k:
+				{
+					bitTiming.prop_seg = 6;
+					bitTiming.phase_seg1 = 7;
+					bitTiming.phase_seg2 = 2;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 15;
+				}
+				break;
+				case B250k:
+				{
+					bitTiming.prop_seg = 6;
+					bitTiming.phase_seg1 = 7;
+					bitTiming.phase_seg2 = 2;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 12;
+				}
+				break;
+				case B400k:
+				{
+					bitTiming.prop_seg = 3;
+					bitTiming.phase_seg1 = 3;
+					bitTiming.phase_seg2 = 1;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 15;
+				}
+				break;
+				case B500k:
+				{
+					bitTiming.prop_seg = 6;
+					bitTiming.phase_seg1 = 7;
+					bitTiming.phase_seg2 = 2;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 6;
+				}
+				break;
+				case B666k:
+				{
+					bitTiming.prop_seg = 3;
+					bitTiming.phase_seg1 = 3;
+					bitTiming.phase_seg2 = 2;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 8;
+				}
+				break;
+				case B800k:
+				{
+					bitTiming.prop_seg = 7;
+					bitTiming.phase_seg1 = 8;
+					bitTiming.phase_seg2 = 4;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 3;
+				}
+				break;
+				case B1000k:
+				{
+					bitTiming.prop_seg = 5;
+					bitTiming.phase_seg1 = 6;
+					bitTiming.phase_seg2 = 4;
+					bitTiming.sjw = 1;
+					bitTiming.brp = 3;
+				}
+				break;
+
+				default:
+				{
+					isobus::CANStackLogger::error("[InnoMaker-Windows] Unsupported baudrate with index " + isobus::to_string(baudrate) + " in InnoMakerUSB2CANWindowsPlugin::Baudrate enum.");
+					return;
+				}
 				break;
 			}
+			driverInstance->urbSetupDevice(device, CAN_MODE, bitTiming);
+			driverInstance->openInnoMakerDevice(device);
 		}
-		if (allChannelsClosed)
+		else
 		{
-			isobus::CANStackLogger::info("[InnoMaker-Windows] All channels closed, closing driver instance");
-			driverInstance->setdown();
-			driverInstance = nullptr;
+			isobus::CANStackLogger::error("[InnoMaker-Windows] No device found on channel " + isobus::to_string(channel));
 		}
 	}
-}
 
-void InnoMakerUSB2CANWindowsPlugin::open()
-{
-	InnoMakerUsb2CanLib::InnoMakerDevice *device = driverInstance->getInnoMakerDevice(channel);
-
-	if (nullptr != device)
+	bool InnoMakerUSB2CANWindowsPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
 	{
-		driverInstance->urbResetDevice(device);
-		driverInstance->closeInnoMakerDevice(device);
+		InnoMakerUsb2CanLib::InnoMakerDevice *device = driverInstance->getInnoMakerDevice(channel);
 
-		// Reset tx buffer according to the documentation
-		for (int i = 0; i < driverInstance->innomaker_MAX_TX_URBS; i++)
+		if (nullptr == device)
 		{
-			txContexts->tx_context[i].echo_id = driverInstance->innomaker_MAX_TX_URBS;
-		}
-
-		InnoMakerUsb2CanLib::Innomaker_device_bittming bitTiming;
-		switch (baudrate)
-		{
-			case B20k:
-			{
-				bitTiming.prop_seg = 6;
-				bitTiming.phase_seg1 = 7;
-				bitTiming.phase_seg2 = 2;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 150;
-			}
-			break;
-			case B33k3:
-			{
-				bitTiming.prop_seg = 3;
-				bitTiming.phase_seg1 = 3;
-				bitTiming.phase_seg2 = 1;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 180;
-			}
-			break;
-			case B40k:
-			{
-				bitTiming.prop_seg = 6;
-				bitTiming.phase_seg1 = 7;
-				bitTiming.phase_seg2 = 2;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 75;
-			}
-			break;
-			case B50k:
-			{
-				bitTiming.prop_seg = 6;
-				bitTiming.phase_seg1 = 7;
-				bitTiming.phase_seg2 = 2;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 60;
-			}
-			break;
-			case B66k6:
-			{
-				bitTiming.prop_seg = 3;
-				bitTiming.phase_seg1 = 3;
-				bitTiming.phase_seg2 = 1;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 90;
-			}
-			break;
-			case B80k:
-			{
-				bitTiming.prop_seg = 3;
-				bitTiming.phase_seg1 = 3;
-				bitTiming.phase_seg2 = 1;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 75;
-			}
-			break;
-			case B83k3:
-			{
-				bitTiming.prop_seg = 3;
-				bitTiming.phase_seg1 = 3;
-				bitTiming.phase_seg2 = 1;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 72;
-			}
-			break;
-			case B100k:
-			{
-				bitTiming.prop_seg = 6;
-				bitTiming.phase_seg1 = 7;
-				bitTiming.phase_seg2 = 2;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 30;
-			}
-			break;
-			case B125k:
-			{
-				bitTiming.prop_seg = 6;
-				bitTiming.phase_seg1 = 7;
-				bitTiming.phase_seg2 = 2;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 24;
-			}
-			break;
-			case B200k:
-			{
-				bitTiming.prop_seg = 6;
-				bitTiming.phase_seg1 = 7;
-				bitTiming.phase_seg2 = 2;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 15;
-			}
-			break;
-			case B250k:
-			{
-				bitTiming.prop_seg = 6;
-				bitTiming.phase_seg1 = 7;
-				bitTiming.phase_seg2 = 2;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 12;
-			}
-			break;
-			case B400k:
-			{
-				bitTiming.prop_seg = 3;
-				bitTiming.phase_seg1 = 3;
-				bitTiming.phase_seg2 = 1;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 15;
-			}
-			break;
-			case B500k:
-			{
-				bitTiming.prop_seg = 6;
-				bitTiming.phase_seg1 = 7;
-				bitTiming.phase_seg2 = 2;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 6;
-			}
-			break;
-			case B666k:
-			{
-				bitTiming.prop_seg = 3;
-				bitTiming.phase_seg1 = 3;
-				bitTiming.phase_seg2 = 2;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 8;
-			}
-			break;
-			case B800k:
-			{
-				bitTiming.prop_seg = 7;
-				bitTiming.phase_seg1 = 8;
-				bitTiming.phase_seg2 = 4;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 3;
-			}
-			break;
-			case B1000k:
-			{
-				bitTiming.prop_seg = 5;
-				bitTiming.phase_seg1 = 6;
-				bitTiming.phase_seg2 = 4;
-				bitTiming.sjw = 1;
-				bitTiming.brp = 3;
-			}
-			break;
-
-			default:
-			{
-				isobus::CANStackLogger::error("[InnoMaker-Windows] Unsupported baudrate with index " + isobus::to_string(baudrate) + " in InnoMakerUSB2CANWindowsPlugin::Baudrate enum.");
-				return;
-			}
-			break;
-		}
-		driverInstance->urbSetupDevice(device, CAN_MODE, bitTiming);
-		driverInstance->openInnoMakerDevice(device);
-	}
-	else
-	{
-		isobus::CANStackLogger::error("[InnoMaker-Windows] No device found on channel " + isobus::to_string(channel));
-	}
-}
-
-bool InnoMakerUSB2CANWindowsPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	InnoMakerUsb2CanLib::InnoMakerDevice *device = driverInstance->getInnoMakerDevice(channel);
-
-	if (nullptr == device)
-	{
-		return false;
-	}
-	BYTE receiveBuffer[sizeof(InnoMakerUsb2CanLib::innomaker_host_frame)];
-	bool success = driverInstance->recvInnoMakerDeviceBuf(device, receiveBuffer, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame), 0xFFFFFFFF);
-	if (!success)
-	{
-		// Most likely a timeout
-		return false;
-	}
-	InnoMakerUsb2CanLib::innomaker_host_frame frame;
-	memcpy(&frame, receiveBuffer, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame));
-
-	if (0xFFFFFFFF != frame.echo_id)
-	{
-		InnoMakerUsb2CanLib::innomaker_tx_context *txc = driverInstance->innomaker_get_tx_context(txContexts.get(), frame.echo_id);
-		if (nullptr == txc)
-		{
-			isobus::CANStackLogger::warn("[InnoMaker-Windows] Received frame with bad echo ID: " + isobus::to_string(static_cast<int>(frame.echo_id)));
 			return false;
 		}
-		driverInstance->innomaker_free_tx_context(txc);
+		BYTE receiveBuffer[sizeof(InnoMakerUsb2CanLib::innomaker_host_frame)];
+		bool success = driverInstance->recvInnoMakerDeviceBuf(device, receiveBuffer, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame), 0xFFFFFFFF);
+		if (!success)
+		{
+			// Most likely a timeout
+			return false;
+		}
+		InnoMakerUsb2CanLib::innomaker_host_frame frame;
+		memcpy(&frame, receiveBuffer, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame));
 
-		/// @todo error frame handling
-		return false;
+		if (0xFFFFFFFF != frame.echo_id)
+		{
+			InnoMakerUsb2CanLib::innomaker_tx_context *txc = driverInstance->innomaker_get_tx_context(txContexts.get(), frame.echo_id);
+			if (nullptr == txc)
+			{
+				isobus::CANStackLogger::warn("[InnoMaker-Windows] Received frame with bad echo ID: " + isobus::to_string(static_cast<int>(frame.echo_id)));
+				return false;
+			}
+			driverInstance->innomaker_free_tx_context(txc);
+
+			/// @todo error frame handling
+			return false;
+		}
+
+		canFrame.dataLength = frame.can_dlc;
+		canFrame.isExtendedFrame = frame.can_id & CAN_EFF_FLAG;
+		if (canFrame.isExtendedFrame)
+		{
+			canFrame.identifier = frame.can_id & CAN_EFF_MASK;
+		}
+		else
+		{
+			canFrame.identifier = frame.can_id & CAN_SFF_MASK;
+		}
+		canFrame.timestamp_us = frame.timestamp_us;
+		memcpy(canFrame.data, frame.data, canFrame.dataLength);
+		return true;
 	}
 
-	canFrame.dataLength = frame.can_dlc;
-	canFrame.isExtendedFrame = frame.can_id & CAN_EFF_FLAG;
-	if (canFrame.isExtendedFrame)
+	bool InnoMakerUSB2CANWindowsPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
 	{
-		canFrame.identifier = frame.can_id & CAN_EFF_MASK;
+		InnoMakerUsb2CanLib::InnoMakerDevice *device = driverInstance->getInnoMakerDevice(channel);
+		if (nullptr == device)
+		{
+			return false;
+		}
+
+		InnoMakerUsb2CanLib::innomaker_tx_context *txc = driverInstance->innomaker_alloc_tx_context(txContexts.get());
+		if (0xFF == txc->echo_id)
+		{
+			isobus::CANStackLogger::debug("[InnoMaker-Windows] No free transmission context");
+			return false;
+		}
+
+		InnoMakerUsb2CanLib::innomaker_host_frame frame;
+		memset(&frame, 0, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame));
+
+		frame.echo_id = txc->echo_id;
+		frame.can_dlc = canFrame.dataLength;
+		frame.can_id = canFrame.identifier;
+		memcpy(frame.data, canFrame.data, canFrame.dataLength);
+
+		if (canFrame.isExtendedFrame)
+		{
+			frame.can_id |= CAN_EFF_FLAG;
+		}
+
+		BYTE sendBuffer[sizeof(InnoMakerUsb2CanLib::innomaker_host_frame)];
+		memcpy(sendBuffer, &frame, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame));
+
+		bool success = driverInstance->sendInnoMakerDeviceBuf(device, sendBuffer, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame), 10);
+		if (!success)
+		{
+			isobus::CANStackLogger::warn("[InnoMaker-Windows] Failed to send frame");
+			driverInstance->innomaker_free_tx_context(txc);
+		}
+		return success;
 	}
-	else
-	{
-		canFrame.identifier = frame.can_id & CAN_SFF_MASK;
-	}
-	canFrame.timestamp_us = frame.timestamp_us;
-	memcpy(canFrame.data, frame.data, canFrame.dataLength);
-	return true;
-}
-
-bool InnoMakerUSB2CANWindowsPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	InnoMakerUsb2CanLib::InnoMakerDevice *device = driverInstance->getInnoMakerDevice(channel);
-	if (nullptr == device)
-	{
-		return false;
-	}
-
-	InnoMakerUsb2CanLib::innomaker_tx_context *txc = driverInstance->innomaker_alloc_tx_context(txContexts.get());
-	if (0xFF == txc->echo_id)
-	{
-		isobus::CANStackLogger::debug("[InnoMaker-Windows] No free transmission context");
-		return false;
-	}
-
-	InnoMakerUsb2CanLib::innomaker_host_frame frame;
-	memset(&frame, 0, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame));
-
-	frame.echo_id = txc->echo_id;
-	frame.can_dlc = canFrame.dataLength;
-	frame.can_id = canFrame.identifier;
-	memcpy(frame.data, canFrame.data, canFrame.dataLength);
-
-	if (canFrame.isExtendedFrame)
-	{
-		frame.can_id |= CAN_EFF_FLAG;
-	}
-
-	BYTE sendBuffer[sizeof(InnoMakerUsb2CanLib::innomaker_host_frame)];
-	memcpy(sendBuffer, &frame, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame));
-
-	bool success = driverInstance->sendInnoMakerDeviceBuf(device, sendBuffer, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame), 10);
-	if (!success)
-	{
-		isobus::CANStackLogger::warn("[InnoMaker-Windows] Failed to send frame");
-		driverInstance->innomaker_free_tx_context(txc);
-	}
-	return success;
 }

--- a/hardware_integration/src/mac_can_pcan_plugin.cpp
+++ b/hardware_integration/src/mac_can_pcan_plugin.cpp
@@ -13,72 +13,75 @@
 
 #include <thread>
 
-MacCANPCANPlugin::MacCANPCANPlugin(WORD channel) :
-  handle(channel),
-  openResult(PCAN_ERROR_OK)
+namespace isobus
 {
-}
-
-MacCANPCANPlugin::~MacCANPCANPlugin()
-{
-}
-
-bool MacCANPCANPlugin::get_is_valid() const
-{
-	return (PCAN_ERROR_OK == openResult);
-}
-
-void MacCANPCANPlugin::close()
-{
-	CAN_Uninitialize(handle);
-}
-
-void MacCANPCANPlugin::open()
-{
-	openResult = CAN_Initialize(handle, PCAN_BAUD_250K);
-
-	if (PCAN_ERROR_OK != openResult)
+	MacCANPCANPlugin::MacCANPCANPlugin(WORD channel) :
+	  handle(channel),
+	  openResult(PCAN_ERROR_OK)
 	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[MacCAN]: Error trying to connect to PCAN probe");
 	}
-}
 
-bool MacCANPCANPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	TPCANStatus result;
-	TPCANMsg CANMsg;
-	TPCANTimestamp CANTimeStamp;
-	bool retVal = false;
-
-	result = CAN_Read(handle, &CANMsg, &CANTimeStamp);
-
-	if (PCAN_ERROR_OK == result)
+	MacCANPCANPlugin::~MacCANPCANPlugin()
 	{
-		canFrame.dataLength = CANMsg.LEN;
-		memcpy(canFrame.data, CANMsg.DATA, CANMsg.LEN);
-		canFrame.identifier = CANMsg.ID;
-		canFrame.isExtendedFrame = (PCAN_MESSAGE_EXTENDED == CANMsg.MSGTYPE);
-		canFrame.timestamp_us = (CANTimeStamp.millis * 1000) + CANTimeStamp.micros;
-		retVal = true;
 	}
-	else
+
+	bool MacCANPCANPlugin::get_is_valid() const
 	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		return (PCAN_ERROR_OK == openResult);
 	}
-	return retVal;
-}
 
-bool MacCANPCANPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	TPCANStatus result;
-	TPCANMsg msgCanMessage;
+	void MacCANPCANPlugin::close()
+	{
+		CAN_Uninitialize(handle);
+	}
 
-	msgCanMessage.ID = canFrame.identifier;
-	msgCanMessage.LEN = canFrame.dataLength;
-	msgCanMessage.MSGTYPE = canFrame.isExtendedFrame ? PCAN_MESSAGE_EXTENDED : PCAN_MESSAGE_STANDARD;
-	memcpy(msgCanMessage.DATA, canFrame.data, canFrame.dataLength);
+	void MacCANPCANPlugin::open()
+	{
+		openResult = CAN_Initialize(handle, PCAN_BAUD_250K);
 
-	result = CAN_Write(handle, &msgCanMessage);
+		if (PCAN_ERROR_OK != openResult)
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[MacCAN]: Error trying to connect to PCAN probe");
+		}
+	}
 
-	return (PCAN_ERROR_OK == result);
+	bool MacCANPCANPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
+	{
+		TPCANStatus result;
+		TPCANMsg CANMsg;
+		TPCANTimestamp CANTimeStamp;
+		bool retVal = false;
+
+		result = CAN_Read(handle, &CANMsg, &CANTimeStamp);
+
+		if (PCAN_ERROR_OK == result)
+		{
+			canFrame.dataLength = CANMsg.LEN;
+			memcpy(canFrame.data, CANMsg.DATA, CANMsg.LEN);
+			canFrame.identifier = CANMsg.ID;
+			canFrame.isExtendedFrame = (PCAN_MESSAGE_EXTENDED == CANMsg.MSGTYPE);
+			canFrame.timestamp_us = (CANTimeStamp.millis * 1000) + CANTimeStamp.micros;
+			retVal = true;
+		}
+		else
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		}
+		return retVal;
+	}
+
+	bool MacCANPCANPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
+	{
+		TPCANStatus result;
+		TPCANMsg msgCanMessage;
+
+		msgCanMessage.ID = canFrame.identifier;
+		msgCanMessage.LEN = canFrame.dataLength;
+		msgCanMessage.MSGTYPE = canFrame.isExtendedFrame ? PCAN_MESSAGE_EXTENDED : PCAN_MESSAGE_STANDARD;
+		memcpy(msgCanMessage.DATA, canFrame.data, canFrame.dataLength);
+
+		result = CAN_Write(handle, &msgCanMessage);
+
+		return (PCAN_ERROR_OK == result);
+	}
 }

--- a/hardware_integration/src/mcp2515_can_interface.cpp
+++ b/hardware_integration/src/mcp2515_can_interface.cpp
@@ -12,342 +12,345 @@
 
 #include <iostream>
 
-MCP2515CANInterface::MCP2515CANInterface(SPIHardwarePlugin *transactionHandler, const std::uint8_t cfg1, const std::uint8_t cfg2, const std::uint8_t cfg3) :
-  transactionHandler(transactionHandler),
-  cfg1(cfg1),
-  cfg2(cfg2),
-  cfg3(cfg3)
+namespace isobus
 {
-}
-
-MCP2515CANInterface::~MCP2515CANInterface()
-{
-	close();
-}
-
-bool MCP2515CANInterface::get_is_valid() const
-{
-	return (transactionHandler) && (initialized);
-}
-
-void MCP2515CANInterface::close()
-{
-	initialized = false;
-}
-
-void MCP2515CANInterface::open()
-{
-	if (reset())
+	MCP2515CANInterface::MCP2515CANInterface(SPIHardwarePlugin *transactionHandler, const std::uint8_t cfg1, const std::uint8_t cfg2, const std::uint8_t cfg3) :
+	  transactionHandler(transactionHandler),
+	  cfg1(cfg1),
+	  cfg2(cfg2),
+	  cfg3(cfg3)
 	{
-		if (set_mode(MCPMode::CONFIG))
+	}
+
+	MCP2515CANInterface::~MCP2515CANInterface()
+	{
+		close();
+	}
+
+	bool MCP2515CANInterface::get_is_valid() const
+	{
+		return (transactionHandler) && (initialized);
+	}
+
+	void MCP2515CANInterface::close()
+	{
+		initialized = false;
+	}
+
+	void MCP2515CANInterface::open()
+	{
+		if (reset())
 		{
-			if ((write_register(MCPRegister::CNF1, cfg1)) &&
-			    (write_register(MCPRegister::CNF2, cfg2)) &&
-			    (write_register(MCPRegister::CNF3, cfg3)))
+			if (set_mode(MCPMode::CONFIG))
 			{
-				if (set_mode(MCPMode::NORMAL))
+				if ((write_register(MCPRegister::CNF1, cfg1)) &&
+				    (write_register(MCPRegister::CNF2, cfg2)) &&
+				    (write_register(MCPRegister::CNF3, cfg3)))
 				{
-					initialized = true;
-				}
-			}
-		}
-	}
-}
-
-bool MCP2515CANInterface::reset()
-{
-	bool retVal = false;
-	if (write_reset())
-	{
-		// Depends on oscillator & capacitors used
-		std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
-		std::uint8_t zeros[14] = { 0 };
-		if ((write_register(MCPRegister::TXB0CTRL, zeros, 14)) &&
-		    (write_register(MCPRegister::TXB1CTRL, zeros, 14)) &&
-		    (write_register(MCPRegister::TXB2CTRL, zeros, 14)) &&
-		    (write_register(MCPRegister::RXB0CTRL, 0)) &&
-		    (write_register(MCPRegister::RXB1CTRL, 0)) &&
-		    (write_register(MCPRegister::CANINTE, 0xA3)))
-		{
-			retVal = true;
-		}
-	}
-	return retVal;
-}
-
-bool MCP2515CANInterface::get_read_status(std::uint8_t &status)
-{
-	bool retVal = false;
-	if (transactionHandler)
-	{
-		const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::READ_STATUS), 0x00 };
-		SPITransactionFrame frame(&txBuffer, true);
-		transactionHandler->begin_transaction();
-		transactionHandler->transmit(&frame);
-		if (transactionHandler->end_transaction())
-		{
-			retVal = true;
-			frame.read_byte(1, status);
-		}
-	}
-	return retVal;
-}
-bool MCP2515CANInterface::read_register(const MCPRegister address, std::uint8_t &data)
-{
-	bool retVal = false;
-	if (transactionHandler)
-	{
-		const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::READ),
-			                                           static_cast<std::uint8_t>(address),
-			                                           0x00 };
-		SPITransactionFrame frame(&txBuffer, true);
-
-		transactionHandler->begin_transaction();
-		transactionHandler->transmit(&frame);
-		if (transactionHandler->end_transaction())
-		{
-			retVal = true;
-			frame.read_byte(2, data);
-		}
-	}
-	return retVal;
-}
-
-bool MCP2515CANInterface::read_register(const MCPRegister address, std::uint8_t *data, const std::size_t length)
-{
-	bool retVal = false;
-	if (transactionHandler)
-	{
-		std::vector<std::uint8_t> txBuffer(2 + length, 0x00);
-		txBuffer[0] = static_cast<std::uint8_t>(MCPInstruction::READ);
-		txBuffer[1] = static_cast<std::uint8_t>(address);
-		SPITransactionFrame frame(&txBuffer, true);
-		transactionHandler->begin_transaction();
-		transactionHandler->transmit(&frame);
-		if (transactionHandler->end_transaction())
-		{
-			retVal = true;
-			frame.read_bytes(2, data, length);
-		}
-	}
-	return retVal;
-}
-
-bool MCP2515CANInterface::modify_register(const MCPRegister address, const std::uint8_t mask, const std::uint8_t data)
-{
-	bool retVal = false;
-	if (transactionHandler)
-	{
-		const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::BITMOD),
-			                                           static_cast<std::uint8_t>(address),
-			                                           mask,
-			                                           data };
-		SPITransactionFrame frame(&txBuffer);
-		transactionHandler->begin_transaction();
-		transactionHandler->transmit(&frame);
-		retVal = transactionHandler->end_transaction();
-	}
-	return retVal;
-}
-
-bool MCP2515CANInterface::write_reset()
-{
-	bool retVal = false;
-	if (transactionHandler)
-	{
-		const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::RESET) };
-		SPITransactionFrame frame(&txBuffer);
-		transactionHandler->begin_transaction();
-		transactionHandler->transmit(&frame);
-		retVal = transactionHandler->end_transaction();
-	}
-	return retVal;
-}
-
-bool MCP2515CANInterface::write_register(const MCPRegister address, const std::uint8_t data)
-{
-	bool retVal = false;
-	if (transactionHandler)
-	{
-		const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::WRITE),
-			                                           static_cast<std::uint8_t>(address),
-			                                           data };
-		SPITransactionFrame frame(&txBuffer);
-		transactionHandler->begin_transaction();
-		transactionHandler->transmit(&frame);
-		retVal = transactionHandler->end_transaction();
-	}
-	return retVal;
-}
-
-bool MCP2515CANInterface::write_register(const MCPRegister address, const std::uint8_t data[], const std::size_t length)
-{
-	bool retVal = false;
-	if (transactionHandler)
-	{
-		std::vector<std::uint8_t> txBuffer(2 + length, 0x00);
-		txBuffer[0] = static_cast<std::uint8_t>(MCPInstruction::WRITE);
-		txBuffer[1] = static_cast<std::uint8_t>(address);
-		memcpy(txBuffer.data() + 2, data, length);
-		SPITransactionFrame frame(&txBuffer);
-
-		transactionHandler->begin_transaction();
-		transactionHandler->transmit(&frame);
-		retVal = transactionHandler->end_transaction();
-	}
-	return retVal;
-}
-
-bool MCP2515CANInterface::set_mode(const MCPMode mode)
-{
-	bool retVal = false;
-	if (modify_register(MCPRegister::CANCTRL, 0xE0, static_cast<std::uint8_t>(mode)))
-	{
-		// Wait for the mode to be set within 10ms
-		const auto start = isobus::SystemTiming::get_timestamp_ms();
-		while (isobus::SystemTiming::get_time_elapsed_ms(start) < 10)
-		{
-			std::uint8_t newMode;
-			if (read_register(MCPRegister::CANSTAT, newMode))
-			{
-				if ((newMode & 0xE0) == static_cast<std::uint8_t>(mode))
-				{
-					retVal = true;
-					break;
-				}
-			}
-		}
-	}
-	return retVal;
-}
-bool MCP2515CANInterface::read_frame(isobus::HardwareInterfaceCANFrame &canFrame,
-                                     const MCPRegister ctrlRegister,
-                                     const MCPRegister dataRegister,
-                                     const std::uint8_t intfMask)
-{
-	bool retVal = false;
-
-	std::uint8_t buffer[6];
-	if (read_register(ctrlRegister, buffer, 6))
-	{
-		canFrame.identifier = (buffer[1] << 3) + (buffer[2] >> 5);
-
-		if (0x08 == (buffer[2] & 0x08))
-		{
-			canFrame.identifier = (canFrame.identifier << 2) + (buffer[2] & 0x03);
-			canFrame.identifier = (canFrame.identifier << 8) + buffer[3];
-			canFrame.identifier = (canFrame.identifier << 8) + buffer[4];
-			canFrame.isExtendedFrame = true;
-		}
-
-		std::uint8_t ctrl = buffer[0];
-		if (ctrl & 0x08)
-		{
-			// TODO: Handle remote frames
-		}
-
-		canFrame.dataLength = (buffer[5] & 0x0F);
-		if (isobus::CAN_DATA_LENGTH >= canFrame.dataLength)
-		{
-			if ((read_register(dataRegister, canFrame.data, canFrame.dataLength)) &&
-			    (modify_register(MCPRegister::CANINTF, intfMask, 0)))
-			{
-				retVal = true;
-			}
-		}
-	}
-	return retVal;
-}
-
-bool MCP2515CANInterface::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	bool retVal = false;
-
-	// TODO: implement interrupt driven message reading
-	std::uint8_t status;
-	while (get_read_status(status))
-	{
-		// Check if any of the buffers have a message
-		if (status & 0x01)
-		{
-			retVal = read_frame(canFrame, MCPRegister::RXB0CTRL, MCPRegister::RXB0DATA, 0x01);
-			break;
-		}
-		else if (status & 0x02)
-		{
-			retVal = read_frame(canFrame, MCPRegister::RXB1CTRL, MCPRegister::RXB1DATA, 0x02);
-			break;
-		}
-
-		std::this_thread::sleep_for(std::chrono::milliseconds(RECEIVE_MESSAGE_READ_RATE));
-	}
-
-	return retVal;
-}
-
-bool MCP2515CANInterface::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame,
-                                      const MCPRegister ctrlRegister,
-                                      const MCPRegister sidhRegister)
-{
-	bool retVal = false;
-
-	// Check if the write buffer is empty
-	std::uint8_t ctrl;
-	if (read_register(ctrlRegister, ctrl))
-	{
-		if ((ctrl & 0x08) == 0)
-		{
-			// Buffer is empty now we can write the buffer
-			std::uint8_t buffer[13];
-			if (canFrame.isExtendedFrame)
-			{
-				buffer[3] = static_cast<std::uint8_t>(canFrame.identifier & 0xFF); //< EID0
-				buffer[2] = static_cast<std::uint8_t>((canFrame.identifier >> 8) & 0xFF); //< EID8
-				buffer[1] = static_cast<std::uint8_t>((canFrame.identifier >> 16) & 0x03); //< SIDL EID17-16
-				buffer[1] |= static_cast<std::uint8_t>((canFrame.identifier >> 13) & 0xE0); //< SIDL SID0-2
-				buffer[1] |= 0x08; //< SIDL exide mask
-				buffer[0] = static_cast<std::uint8_t>((canFrame.identifier >> 21) & 0xFF); //< SIDH
-			}
-			else
-			{
-				buffer[1] = static_cast<std::uint8_t>((canFrame.identifier << 5) & 0xE0); // SIDL
-				buffer[0] = static_cast<std::uint8_t>(canFrame.identifier >> 3); // SIDH
-			}
-
-			buffer[4] = canFrame.dataLength; //< DLC
-			memcpy(&buffer[5], canFrame.data, canFrame.dataLength); //< Data
-			if (write_register(sidhRegister, buffer, 5 + canFrame.dataLength))
-			{
-				// Now indicate that the buffer is ready to be sent
-				if (modify_register(ctrlRegister, 0x08, 0x08))
-				{
-					// Now check if the buffer was sent
-					if (read_register(ctrlRegister, ctrl))
+					if (set_mode(MCPMode::NORMAL))
 					{
-						if (0 == (ctrl & (0x40 | 0x20 | 0x10)))
-						{
-							retVal = true;
-						}
+						initialized = true;
 					}
 				}
 			}
 		}
 	}
 
-	return retVal;
-}
+	bool MCP2515CANInterface::reset()
+	{
+		bool retVal = false;
+		if (write_reset())
+		{
+			// Depends on oscillator & capacitors used
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
-bool MCP2515CANInterface::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	bool retVal = write_frame(canFrame, MCPRegister::TXB0CTRL, MCPRegister::TXB0SIDH);
-	if (!retVal)
-	{
-		retVal = write_frame(canFrame, MCPRegister::TXB1CTRL, MCPRegister::TXB1SIDH);
+			std::uint8_t zeros[14] = { 0 };
+			if ((write_register(MCPRegister::TXB0CTRL, zeros, 14)) &&
+			    (write_register(MCPRegister::TXB1CTRL, zeros, 14)) &&
+			    (write_register(MCPRegister::TXB2CTRL, zeros, 14)) &&
+			    (write_register(MCPRegister::RXB0CTRL, 0)) &&
+			    (write_register(MCPRegister::RXB1CTRL, 0)) &&
+			    (write_register(MCPRegister::CANINTE, 0xA3)))
+			{
+				retVal = true;
+			}
+		}
+		return retVal;
 	}
-	if (!retVal)
+
+	bool MCP2515CANInterface::get_read_status(std::uint8_t &status)
 	{
-		retVal = write_frame(canFrame, MCPRegister::TXB2CTRL, MCPRegister::TXB2SIDH);
+		bool retVal = false;
+		if (transactionHandler)
+		{
+			const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::READ_STATUS), 0x00 };
+			SPITransactionFrame frame(&txBuffer, true);
+			transactionHandler->begin_transaction();
+			transactionHandler->transmit(&frame);
+			if (transactionHandler->end_transaction())
+			{
+				retVal = true;
+				frame.read_byte(1, status);
+			}
+		}
+		return retVal;
 	}
-	return retVal;
+	bool MCP2515CANInterface::read_register(const MCPRegister address, std::uint8_t &data)
+	{
+		bool retVal = false;
+		if (transactionHandler)
+		{
+			const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::READ),
+				                                           static_cast<std::uint8_t>(address),
+				                                           0x00 };
+			SPITransactionFrame frame(&txBuffer, true);
+
+			transactionHandler->begin_transaction();
+			transactionHandler->transmit(&frame);
+			if (transactionHandler->end_transaction())
+			{
+				retVal = true;
+				frame.read_byte(2, data);
+			}
+		}
+		return retVal;
+	}
+
+	bool MCP2515CANInterface::read_register(const MCPRegister address, std::uint8_t *data, const std::size_t length)
+	{
+		bool retVal = false;
+		if (transactionHandler)
+		{
+			std::vector<std::uint8_t> txBuffer(2 + length, 0x00);
+			txBuffer[0] = static_cast<std::uint8_t>(MCPInstruction::READ);
+			txBuffer[1] = static_cast<std::uint8_t>(address);
+			SPITransactionFrame frame(&txBuffer, true);
+			transactionHandler->begin_transaction();
+			transactionHandler->transmit(&frame);
+			if (transactionHandler->end_transaction())
+			{
+				retVal = true;
+				frame.read_bytes(2, data, length);
+			}
+		}
+		return retVal;
+	}
+
+	bool MCP2515CANInterface::modify_register(const MCPRegister address, const std::uint8_t mask, const std::uint8_t data)
+	{
+		bool retVal = false;
+		if (transactionHandler)
+		{
+			const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::BITMOD),
+				                                           static_cast<std::uint8_t>(address),
+				                                           mask,
+				                                           data };
+			SPITransactionFrame frame(&txBuffer);
+			transactionHandler->begin_transaction();
+			transactionHandler->transmit(&frame);
+			retVal = transactionHandler->end_transaction();
+		}
+		return retVal;
+	}
+
+	bool MCP2515CANInterface::write_reset()
+	{
+		bool retVal = false;
+		if (transactionHandler)
+		{
+			const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::RESET) };
+			SPITransactionFrame frame(&txBuffer);
+			transactionHandler->begin_transaction();
+			transactionHandler->transmit(&frame);
+			retVal = transactionHandler->end_transaction();
+		}
+		return retVal;
+	}
+
+	bool MCP2515CANInterface::write_register(const MCPRegister address, const std::uint8_t data)
+	{
+		bool retVal = false;
+		if (transactionHandler)
+		{
+			const std::vector<std::uint8_t> txBuffer = { static_cast<std::uint8_t>(MCPInstruction::WRITE),
+				                                           static_cast<std::uint8_t>(address),
+				                                           data };
+			SPITransactionFrame frame(&txBuffer);
+			transactionHandler->begin_transaction();
+			transactionHandler->transmit(&frame);
+			retVal = transactionHandler->end_transaction();
+		}
+		return retVal;
+	}
+
+	bool MCP2515CANInterface::write_register(const MCPRegister address, const std::uint8_t data[], const std::size_t length)
+	{
+		bool retVal = false;
+		if (transactionHandler)
+		{
+			std::vector<std::uint8_t> txBuffer(2 + length, 0x00);
+			txBuffer[0] = static_cast<std::uint8_t>(MCPInstruction::WRITE);
+			txBuffer[1] = static_cast<std::uint8_t>(address);
+			memcpy(txBuffer.data() + 2, data, length);
+			SPITransactionFrame frame(&txBuffer);
+
+			transactionHandler->begin_transaction();
+			transactionHandler->transmit(&frame);
+			retVal = transactionHandler->end_transaction();
+		}
+		return retVal;
+	}
+
+	bool MCP2515CANInterface::set_mode(const MCPMode mode)
+	{
+		bool retVal = false;
+		if (modify_register(MCPRegister::CANCTRL, 0xE0, static_cast<std::uint8_t>(mode)))
+		{
+			// Wait for the mode to be set within 10ms
+			const auto start = isobus::SystemTiming::get_timestamp_ms();
+			while (isobus::SystemTiming::get_time_elapsed_ms(start) < 10)
+			{
+				std::uint8_t newMode;
+				if (read_register(MCPRegister::CANSTAT, newMode))
+				{
+					if ((newMode & 0xE0) == static_cast<std::uint8_t>(mode))
+					{
+						retVal = true;
+						break;
+					}
+				}
+			}
+		}
+		return retVal;
+	}
+	bool MCP2515CANInterface::read_frame(isobus::HardwareInterfaceCANFrame &canFrame,
+	                                     const MCPRegister ctrlRegister,
+	                                     const MCPRegister dataRegister,
+	                                     const std::uint8_t intfMask)
+	{
+		bool retVal = false;
+
+		std::uint8_t buffer[6];
+		if (read_register(ctrlRegister, buffer, 6))
+		{
+			canFrame.identifier = (buffer[1] << 3) + (buffer[2] >> 5);
+
+			if (0x08 == (buffer[2] & 0x08))
+			{
+				canFrame.identifier = (canFrame.identifier << 2) + (buffer[2] & 0x03);
+				canFrame.identifier = (canFrame.identifier << 8) + buffer[3];
+				canFrame.identifier = (canFrame.identifier << 8) + buffer[4];
+				canFrame.isExtendedFrame = true;
+			}
+
+			std::uint8_t ctrl = buffer[0];
+			if (ctrl & 0x08)
+			{
+				// TODO: Handle remote frames
+			}
+
+			canFrame.dataLength = (buffer[5] & 0x0F);
+			if (isobus::CAN_DATA_LENGTH >= canFrame.dataLength)
+			{
+				if ((read_register(dataRegister, canFrame.data, canFrame.dataLength)) &&
+				    (modify_register(MCPRegister::CANINTF, intfMask, 0)))
+				{
+					retVal = true;
+				}
+			}
+		}
+		return retVal;
+	}
+
+	bool MCP2515CANInterface::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
+	{
+		bool retVal = false;
+
+		// TODO: implement interrupt driven message reading
+		std::uint8_t status;
+		while (get_read_status(status))
+		{
+			// Check if any of the buffers have a message
+			if (status & 0x01)
+			{
+				retVal = read_frame(canFrame, MCPRegister::RXB0CTRL, MCPRegister::RXB0DATA, 0x01);
+				break;
+			}
+			else if (status & 0x02)
+			{
+				retVal = read_frame(canFrame, MCPRegister::RXB1CTRL, MCPRegister::RXB1DATA, 0x02);
+				break;
+			}
+
+			std::this_thread::sleep_for(std::chrono::milliseconds(RECEIVE_MESSAGE_READ_RATE));
+		}
+
+		return retVal;
+	}
+
+	bool MCP2515CANInterface::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame,
+	                                      const MCPRegister ctrlRegister,
+	                                      const MCPRegister sidhRegister)
+	{
+		bool retVal = false;
+
+		// Check if the write buffer is empty
+		std::uint8_t ctrl;
+		if (read_register(ctrlRegister, ctrl))
+		{
+			if ((ctrl & 0x08) == 0)
+			{
+				// Buffer is empty now we can write the buffer
+				std::uint8_t buffer[13];
+				if (canFrame.isExtendedFrame)
+				{
+					buffer[3] = static_cast<std::uint8_t>(canFrame.identifier & 0xFF); //< EID0
+					buffer[2] = static_cast<std::uint8_t>((canFrame.identifier >> 8) & 0xFF); //< EID8
+					buffer[1] = static_cast<std::uint8_t>((canFrame.identifier >> 16) & 0x03); //< SIDL EID17-16
+					buffer[1] |= static_cast<std::uint8_t>((canFrame.identifier >> 13) & 0xE0); //< SIDL SID0-2
+					buffer[1] |= 0x08; //< SIDL exide mask
+					buffer[0] = static_cast<std::uint8_t>((canFrame.identifier >> 21) & 0xFF); //< SIDH
+				}
+				else
+				{
+					buffer[1] = static_cast<std::uint8_t>((canFrame.identifier << 5) & 0xE0); // SIDL
+					buffer[0] = static_cast<std::uint8_t>(canFrame.identifier >> 3); // SIDH
+				}
+
+				buffer[4] = canFrame.dataLength; //< DLC
+				memcpy(&buffer[5], canFrame.data, canFrame.dataLength); //< Data
+				if (write_register(sidhRegister, buffer, 5 + canFrame.dataLength))
+				{
+					// Now indicate that the buffer is ready to be sent
+					if (modify_register(ctrlRegister, 0x08, 0x08))
+					{
+						// Now check if the buffer was sent
+						if (read_register(ctrlRegister, ctrl))
+						{
+							if (0 == (ctrl & (0x40 | 0x20 | 0x10)))
+							{
+								retVal = true;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return retVal;
+	}
+
+	bool MCP2515CANInterface::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
+	{
+		bool retVal = write_frame(canFrame, MCPRegister::TXB0CTRL, MCPRegister::TXB0SIDH);
+		if (!retVal)
+		{
+			retVal = write_frame(canFrame, MCPRegister::TXB1CTRL, MCPRegister::TXB1SIDH);
+		}
+		if (!retVal)
+		{
+			retVal = write_frame(canFrame, MCPRegister::TXB2CTRL, MCPRegister::TXB2SIDH);
+		}
+		return retVal;
+	}
 }

--- a/hardware_integration/src/socket_can_interface.cpp
+++ b/hardware_integration/src/socket_can_interface.cpp
@@ -23,72 +23,79 @@
 #include <cstring>
 #include <limits>
 
-SocketCANInterface::SocketCANInterface(const std::string deviceName) :
-  pCANDevice(new sockaddr_can),
-  name(deviceName),
-  fileDescriptor(-1)
+namespace isobus
 {
-	if (nullptr != pCANDevice)
+	SocketCANInterface::SocketCANInterface(const std::string deviceName) :
+	  pCANDevice(new sockaddr_can),
+	  name(deviceName),
+	  fileDescriptor(-1)
 	{
-		std::memset(pCANDevice, 0, sizeof(struct sockaddr_can));
-	}
-}
-
-SocketCANInterface::~SocketCANInterface()
-{
-	close();
-
-	if (nullptr != pCANDevice)
-	{
-		delete pCANDevice;
-		pCANDevice = nullptr;
-	}
-}
-
-bool SocketCANInterface::get_is_valid() const
-{
-	return (-1 != fileDescriptor);
-}
-
-std::string SocketCANInterface::get_device_name() const
-{
-	return name;
-}
-
-void SocketCANInterface::close()
-{
-	::close(fileDescriptor);
-	fileDescriptor = -1;
-}
-
-void SocketCANInterface::open()
-{
-	fileDescriptor = socket(PF_CAN, SOCK_RAW, CAN_RAW);
-
-	if (fileDescriptor >= 0)
-	{
-		struct ifreq interfaceRequestStructure;
-		const int RECEIVE_OWN_MESSAGES = 0;
-		const int DROP_MONITOR = 1;
-		const int TIMESTAMPING = 0x58;
-		const int TIMESTAMP = 1;
-		memset(&interfaceRequestStructure, 0, sizeof(interfaceRequestStructure));
-		strncpy(interfaceRequestStructure.ifr_name, name.c_str(), sizeof(interfaceRequestStructure.ifr_name));
-		setsockopt(fileDescriptor, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, &RECEIVE_OWN_MESSAGES, sizeof(RECEIVE_OWN_MESSAGES));
-		setsockopt(fileDescriptor, SOL_SOCKET, SO_RXQ_OVFL, &DROP_MONITOR, sizeof(DROP_MONITOR));
-
-		if (setsockopt(fileDescriptor, SOL_SOCKET, SO_TIMESTAMPING, &TIMESTAMPING, sizeof(TIMESTAMPING)) < 0)
+		if (nullptr != pCANDevice)
 		{
-			setsockopt(fileDescriptor, SOL_SOCKET, SO_TIMESTAMP, &TIMESTAMP, sizeof(TIMESTAMP));
+			std::memset(pCANDevice, 0, sizeof(struct sockaddr_can));
 		}
+	}
 
-		if (ioctl(fileDescriptor, SIOCGIFINDEX, &interfaceRequestStructure) >= 0)
+	SocketCANInterface::~SocketCANInterface()
+	{
+		close();
+
+		if (nullptr != pCANDevice)
 		{
-			memset(pCANDevice, 0, sizeof(sockaddr_can));
-			pCANDevice->can_family = AF_CAN;
-			pCANDevice->can_ifindex = interfaceRequestStructure.ifr_ifindex;
+			delete pCANDevice;
+			pCANDevice = nullptr;
+		}
+	}
 
-			if (bind(fileDescriptor, (struct sockaddr *)pCANDevice, sizeof(struct sockaddr)) < 0)
+	bool SocketCANInterface::get_is_valid() const
+	{
+		return (-1 != fileDescriptor);
+	}
+
+	std::string SocketCANInterface::get_device_name() const
+	{
+		return name;
+	}
+
+	void SocketCANInterface::close()
+	{
+		::close(fileDescriptor);
+		fileDescriptor = -1;
+	}
+
+	void SocketCANInterface::open()
+	{
+		fileDescriptor = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+
+		if (fileDescriptor >= 0)
+		{
+			struct ifreq interfaceRequestStructure;
+			const int RECEIVE_OWN_MESSAGES = 0;
+			const int DROP_MONITOR = 1;
+			const int TIMESTAMPING = 0x58;
+			const int TIMESTAMP = 1;
+			memset(&interfaceRequestStructure, 0, sizeof(interfaceRequestStructure));
+			strncpy(interfaceRequestStructure.ifr_name, name.c_str(), sizeof(interfaceRequestStructure.ifr_name));
+			setsockopt(fileDescriptor, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, &RECEIVE_OWN_MESSAGES, sizeof(RECEIVE_OWN_MESSAGES));
+			setsockopt(fileDescriptor, SOL_SOCKET, SO_RXQ_OVFL, &DROP_MONITOR, sizeof(DROP_MONITOR));
+
+			if (setsockopt(fileDescriptor, SOL_SOCKET, SO_TIMESTAMPING, &TIMESTAMPING, sizeof(TIMESTAMPING)) < 0)
+			{
+				setsockopt(fileDescriptor, SOL_SOCKET, SO_TIMESTAMP, &TIMESTAMP, sizeof(TIMESTAMP));
+			}
+
+			if (ioctl(fileDescriptor, SIOCGIFINDEX, &interfaceRequestStructure) >= 0)
+			{
+				memset(pCANDevice, 0, sizeof(sockaddr_can));
+				pCANDevice->can_family = AF_CAN;
+				pCANDevice->can_ifindex = interfaceRequestStructure.ifr_ifindex;
+
+				if (bind(fileDescriptor, (struct sockaddr *)pCANDevice, sizeof(struct sockaddr)) < 0)
+				{
+					close();
+				}
+			}
+			else
 			{
 				close();
 			}
@@ -98,119 +105,115 @@ void SocketCANInterface::open()
 			close();
 		}
 	}
-	else
+
+	bool SocketCANInterface::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
 	{
-		close();
-	}
-}
+		struct pollfd pollingFileDescriptor;
+		bool retVal = false;
 
-bool SocketCANInterface::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	struct pollfd pollingFileDescriptor;
-	bool retVal = false;
+		pollingFileDescriptor.fd = fileDescriptor;
+		pollingFileDescriptor.events = POLLIN;
+		pollingFileDescriptor.revents = 0;
 
-	pollingFileDescriptor.fd = fileDescriptor;
-	pollingFileDescriptor.events = POLLIN;
-	pollingFileDescriptor.revents = 0;
-
-	if (1 == poll(&pollingFileDescriptor, 1, 100))
-	{
-		canFrame.timestamp_us = std::numeric_limits<std::uint64_t>::max();
-		struct can_frame txFrame;
-		struct msghdr message;
-		struct iovec segment;
-
-		char lControlMessage[CMSG_SPACE(sizeof(struct timeval) + (3 * sizeof(struct timespec)) + sizeof(std::uint32_t))];
-
-		segment.iov_base = &txFrame;
-		segment.iov_len = sizeof(struct can_frame);
-		message.msg_iov = &segment;
-		message.msg_iovlen = 1;
-		message.msg_control = &lControlMessage;
-		message.msg_controllen = sizeof(lControlMessage);
-		message.msg_name = pCANDevice;
-		message.msg_namelen = sizeof(struct sockaddr_can);
-		message.msg_flags = 0;
-
-		if (recvmsg(fileDescriptor, &message, 0) > 0)
+		if (1 == poll(&pollingFileDescriptor, 1, 100))
 		{
-			if (0 == (txFrame.can_id & CAN_ERR_FLAG))
+			canFrame.timestamp_us = std::numeric_limits<std::uint64_t>::max();
+			struct can_frame txFrame;
+			struct msghdr message;
+			struct iovec segment;
+
+			char lControlMessage[CMSG_SPACE(sizeof(struct timeval) + (3 * sizeof(struct timespec)) + sizeof(std::uint32_t))];
+
+			segment.iov_base = &txFrame;
+			segment.iov_len = sizeof(struct can_frame);
+			message.msg_iov = &segment;
+			message.msg_iovlen = 1;
+			message.msg_control = &lControlMessage;
+			message.msg_controllen = sizeof(lControlMessage);
+			message.msg_name = pCANDevice;
+			message.msg_namelen = sizeof(struct sockaddr_can);
+			message.msg_flags = 0;
+
+			if (recvmsg(fileDescriptor, &message, 0) > 0)
 			{
-				if (0 != (txFrame.can_id & CAN_EFF_FLAG))
+				if (0 == (txFrame.can_id & CAN_ERR_FLAG))
 				{
-					canFrame.identifier = (txFrame.can_id & CAN_EFF_MASK);
-					canFrame.isExtendedFrame = true;
-				}
-				else
-				{
-					canFrame.identifier = (txFrame.can_id & CAN_SFF_MASK);
-					canFrame.isExtendedFrame = false;
-				}
-				canFrame.dataLength = txFrame.can_dlc;
-				memset(canFrame.data, 0, sizeof(canFrame.data));
-				memcpy(canFrame.data, txFrame.data, canFrame.dataLength);
-
-				for (struct cmsghdr *pControlMessage = CMSG_FIRSTHDR(&message); (nullptr != pControlMessage) && (SOL_SOCKET == pControlMessage->cmsg_level); pControlMessage = CMSG_NXTHDR(&message, pControlMessage))
-				{
-					switch (pControlMessage->cmsg_type)
+					if (0 != (txFrame.can_id & CAN_EFF_FLAG))
 					{
-						case SO_TIMESTAMP:
-						{
-							struct timeval *time = (struct timeval *)CMSG_DATA(pControlMessage);
-
-							if (std::numeric_limits<std::uint64_t>::max() == canFrame.timestamp_us)
-							{
-								canFrame.timestamp_us = static_cast<std::uint64_t>(time->tv_usec) + (static_cast<std::uint64_t>(time->tv_sec) * 1000000);
-							}
-						}
-						break;
-
-						case SO_TIMESTAMPING:
-						{
-							struct timespec *time = (struct timespec *)(CMSG_DATA(pControlMessage));
-							canFrame.timestamp_us = (static_cast<std::uint64_t>(time[2].tv_nsec) / 1000) + (static_cast<std::uint64_t>(time[2].tv_sec) * 1000000);
-						}
-						break;
+						canFrame.identifier = (txFrame.can_id & CAN_EFF_MASK);
+						canFrame.isExtendedFrame = true;
 					}
+					else
+					{
+						canFrame.identifier = (txFrame.can_id & CAN_SFF_MASK);
+						canFrame.isExtendedFrame = false;
+					}
+					canFrame.dataLength = txFrame.can_dlc;
+					memset(canFrame.data, 0, sizeof(canFrame.data));
+					memcpy(canFrame.data, txFrame.data, canFrame.dataLength);
+
+					for (struct cmsghdr *pControlMessage = CMSG_FIRSTHDR(&message); (nullptr != pControlMessage) && (SOL_SOCKET == pControlMessage->cmsg_level); pControlMessage = CMSG_NXTHDR(&message, pControlMessage))
+					{
+						switch (pControlMessage->cmsg_type)
+						{
+							case SO_TIMESTAMP:
+							{
+								struct timeval *time = (struct timeval *)CMSG_DATA(pControlMessage);
+
+								if (std::numeric_limits<std::uint64_t>::max() == canFrame.timestamp_us)
+								{
+									canFrame.timestamp_us = static_cast<std::uint64_t>(time->tv_usec) + (static_cast<std::uint64_t>(time->tv_sec) * 1000000);
+								}
+							}
+							break;
+
+							case SO_TIMESTAMPING:
+							{
+								struct timespec *time = (struct timespec *)(CMSG_DATA(pControlMessage));
+								canFrame.timestamp_us = (static_cast<std::uint64_t>(time[2].tv_nsec) / 1000) + (static_cast<std::uint64_t>(time[2].tv_sec) * 1000000);
+							}
+							break;
+						}
+					}
+					retVal = true;
 				}
-				retVal = true;
 			}
+			else if (errno == ENETDOWN)
+			{
+				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SocketCAN] " + get_device_name() + " interface is down.");
+				close();
+			}
+		}
+		else if (pollingFileDescriptor.revents & (POLLERR | POLLHUP))
+		{
+			close();
+		}
+		return retVal;
+	}
+
+	bool SocketCANInterface::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
+	{
+		struct can_frame txFrame;
+		bool retVal = false;
+
+		txFrame.can_id = canFrame.identifier;
+		txFrame.can_dlc = canFrame.dataLength;
+		memcpy(txFrame.data, canFrame.data, canFrame.dataLength);
+
+		if (canFrame.isExtendedFrame)
+		{
+			txFrame.can_id |= CAN_EFF_FLAG;
+		}
+
+		if (write(fileDescriptor, &txFrame, sizeof(struct can_frame)) > 0)
+		{
+			retVal = true;
 		}
 		else if (errno == ENETDOWN)
 		{
 			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SocketCAN] " + get_device_name() + " interface is down.");
 			close();
 		}
+		return retVal;
 	}
-	else if (pollingFileDescriptor.revents & (POLLERR | POLLHUP))
-	{
-		close();
-	}
-	return retVal;
-}
-
-bool SocketCANInterface::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	struct can_frame txFrame;
-	bool retVal = false;
-
-	txFrame.can_id = canFrame.identifier;
-	txFrame.can_dlc = canFrame.dataLength;
-	memcpy(txFrame.data, canFrame.data, canFrame.dataLength);
-
-	if (canFrame.isExtendedFrame)
-	{
-		txFrame.can_id |= CAN_EFF_FLAG;
-	}
-
-	if (write(fileDescriptor, &txFrame, sizeof(struct can_frame)) > 0)
-	{
-		retVal = true;
-	}
-	else if (errno == ENETDOWN)
-	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SocketCAN] " + get_device_name() + " interface is down.");
-		close();
-	}
-	return retVal;
 }

--- a/hardware_integration/src/spi_interface_esp.cpp
+++ b/hardware_integration/src/spi_interface_esp.cpp
@@ -13,92 +13,95 @@
 
 #include <cstring>
 
-SPIInterfaceESP::SPIInterfaceESP(const spi_device_interface_config_t *deviceConfig, const spi_host_device_t hostDevice) :
-  deviceConfig(deviceConfig),
-  hostDevice(hostDevice),
-  spiMutex(xSemaphoreCreateMutex()),
-  initialized(false),
-  success(true) {}
-
-SPIInterfaceESP::~SPIInterfaceESP()
+namespace isobus
 {
-	deinit();
-	vSemaphoreDelete(spiMutex);
-}
+	SPIInterfaceESP::SPIInterfaceESP(const spi_device_interface_config_t *deviceConfig, const spi_host_device_t hostDevice) :
+	  deviceConfig(deviceConfig),
+	  hostDevice(hostDevice),
+	  spiMutex(xSemaphoreCreateMutex()),
+	  initialized(false),
+	  success(true) {}
 
-bool SPIInterfaceESP::init()
-{
-	esp_err_t error = spi_bus_add_device(hostDevice, deviceConfig, &spiDevice);
-	if (ESP_OK == error)
+	SPIInterfaceESP::~SPIInterfaceESP()
 	{
-		initialized = true;
-	}
-	else
-	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SPI-ESP] Failed to add SPI device: " + isobus::to_string(esp_err_to_name(error)));
+		deinit();
+		vSemaphoreDelete(spiMutex);
 	}
 
-	return ESP_OK == error;
-}
-
-void SPIInterfaceESP::deinit()
-{
-	esp_err_t error = spi_bus_remove_device(spiDevice);
-	if (ESP_OK != error)
+	bool SPIInterfaceESP::init()
 	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPI-ESP] Failed to remove SPI device: " + isobus::to_string(esp_err_to_name(error)));
-	}
-	if (ESP_ERR_INVALID_STATE == error || ESP_OK == error)
-	{
-		initialized = false;
-	}
-}
-
-void SPIInterfaceESP::transmit(SPITransactionFrame *frame)
-{
-	if (initialized)
-	{
-		if (xSemaphoreTake(spiMutex, MAX_TIME_TO_WAIT) == pdTRUE)
+		esp_err_t error = spi_bus_add_device(hostDevice, deviceConfig, &spiDevice);
+		if (ESP_OK == error)
 		{
-			spi_transaction_t transaction;
-			std::memset(&transaction, 0, sizeof(transaction));
+			initialized = true;
+		}
+		else
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SPI-ESP] Failed to add SPI device: " + isobus::to_string(esp_err_to_name(error)));
+		}
 
-			transaction.length = frame->get_tx_buffer()->size() * 8;
-			transaction.tx_buffer = frame->get_tx_buffer()->data();
-			if (frame->get_is_read())
+		return ESP_OK == error;
+	}
+
+	void SPIInterfaceESP::deinit()
+	{
+		esp_err_t error = spi_bus_remove_device(spiDevice);
+		if (ESP_OK != error)
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPI-ESP] Failed to remove SPI device: " + isobus::to_string(esp_err_to_name(error)));
+		}
+		if (ESP_ERR_INVALID_STATE == error || ESP_OK == error)
+		{
+			initialized = false;
+		}
+	}
+
+	void SPIInterfaceESP::transmit(SPITransactionFrame *frame)
+	{
+		if (initialized)
+		{
+			if (xSemaphoreTake(spiMutex, MAX_TIME_TO_WAIT) == pdTRUE)
 			{
-				frame->get_rx_buffer().resize(frame->get_tx_buffer()->size());
-				transaction.rx_buffer = frame->get_rx_buffer().data();
+				spi_transaction_t transaction;
+				std::memset(&transaction, 0, sizeof(transaction));
+
+				transaction.length = frame->get_tx_buffer()->size() * 8;
+				transaction.tx_buffer = frame->get_tx_buffer()->data();
+				if (frame->get_is_read())
+				{
+					frame->get_rx_buffer().resize(frame->get_tx_buffer()->size());
+					transaction.rx_buffer = frame->get_rx_buffer().data();
+				}
+				else
+				{
+					transaction.rx_buffer = nullptr;
+				}
+
+				esp_err_t error = spi_device_transmit(spiDevice, &transaction);
+				if (ESP_OK != error)
+				{
+					success = false;
+					isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Warning, "[SPI-ESP] Failed to transmit SPI transaction frame: " + isobus::to_string(esp_err_to_name(error)));
+				}
+				xSemaphoreGive(spiMutex);
 			}
 			else
 			{
-				transaction.rx_buffer = nullptr;
-			}
-
-			esp_err_t error = spi_device_transmit(spiDevice, &transaction);
-			if (ESP_OK != error)
-			{
 				success = false;
-				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Warning, "[SPI-ESP] Failed to transmit SPI transaction frame: " + isobus::to_string(esp_err_to_name(error)));
+				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPI-ESP] Failed to obtain SPI mutex in transmit().");
 			}
-			xSemaphoreGive(spiMutex);
 		}
 		else
 		{
 			success = false;
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPI-ESP] Failed to obtain SPI mutex in transmit().");
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SPI-ESP] SPI device not initialized, pherhaps you forgot to call init()?");
 		}
 	}
-	else
-	{
-		success = false;
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SPI-ESP] SPI device not initialized, pherhaps you forgot to call init()?");
-	}
-}
 
-bool SPIInterfaceESP::end_transaction()
-{
-	bool retVal = success;
-	success = true; // Reset success flag for next transaction
-	return retVal;
+	bool SPIInterfaceESP::end_transaction()
+	{
+		bool retVal = success;
+		success = true; // Reset success flag for next transaction
+		return retVal;
+	}
 }

--- a/hardware_integration/src/spi_transaction_frame.cpp
+++ b/hardware_integration/src/spi_transaction_frame.cpp
@@ -12,73 +12,76 @@
 
 #include <cstring>
 
-SPITransactionFrame::SPITransactionFrame(const std::vector<std::uint8_t> *txBuffer, bool read) :
-  txBuffer(txBuffer),
-  read(read),
-  rxBuffer({})
+namespace isobus
 {
-	if (read)
+	SPITransactionFrame::SPITransactionFrame(const std::vector<std::uint8_t> *txBuffer, bool read) :
+	  txBuffer(txBuffer),
+	  read(read),
+	  rxBuffer({})
 	{
-		rxBuffer.reserve(txBuffer->size());
-	}
-}
-
-bool SPITransactionFrame::read_byte(std::size_t index, std::uint8_t &byte) const
-{
-	bool retVal = false;
-
-	if (read)
-	{
-		if (index < rxBuffer.size())
+		if (read)
 		{
-			byte = rxBuffer[index];
-			retVal = true;
+			rxBuffer.reserve(txBuffer->size());
+		}
+	}
+
+	bool SPITransactionFrame::read_byte(std::size_t index, std::uint8_t &byte) const
+	{
+		bool retVal = false;
+
+		if (read)
+		{
+			if (index < rxBuffer.size())
+			{
+				byte = rxBuffer[index];
+				retVal = true;
+			}
+			else
+			{
+				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] Tried to read byte at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
+			}
 		}
 		else
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] Tried to read byte at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] The transaction was not configured to read, but tried to read byte at index: " + isobus::to_string(index));
 		}
+		return retVal;
 	}
-	else
-	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] The transaction was not configured to read, but tried to read byte at index: " + isobus::to_string(index));
-	}
-	return retVal;
-}
 
-bool SPITransactionFrame::read_bytes(std::size_t index, std::uint8_t *buffer, std::size_t length) const
-{
-	bool retVal = false;
-	if (read)
+	bool SPITransactionFrame::read_bytes(std::size_t index, std::uint8_t *buffer, std::size_t length) const
 	{
-		if (index + length <= rxBuffer.size())
+		bool retVal = false;
+		if (read)
 		{
-			std::memcpy(buffer, &rxBuffer[index], length);
-			retVal = true;
+			if (index + length <= rxBuffer.size())
+			{
+				std::memcpy(buffer, &rxBuffer[index], length);
+				retVal = true;
+			}
+			else
+			{
+				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] Tried to read " + isobus::to_string(length) + " bytes at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
+			}
 		}
 		else
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] Tried to read " + isobus::to_string(length) + " bytes at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] The transaction was not configured to read, but tried to read " + isobus::to_string(length) + " bytes at index: " + isobus::to_string(index));
 		}
+		return retVal;
 	}
-	else
+
+	std::vector<std::uint8_t> &SPITransactionFrame::get_rx_buffer()
 	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] The transaction was not configured to read, but tried to read " + isobus::to_string(length) + " bytes at index: " + isobus::to_string(index));
+		return rxBuffer;
 	}
-	return retVal;
-}
 
-std::vector<std::uint8_t> &SPITransactionFrame::get_rx_buffer()
-{
-	return rxBuffer;
-}
+	const std::vector<std::uint8_t> *SPITransactionFrame::get_tx_buffer() const
+	{
+		return txBuffer;
+	}
 
-const std::vector<std::uint8_t> *SPITransactionFrame::get_tx_buffer() const
-{
-	return txBuffer;
-}
-
-bool SPITransactionFrame::get_is_read() const
-{
-	return read;
+	bool SPITransactionFrame::get_is_read() const
+	{
+		return read;
+	}
 }

--- a/hardware_integration/src/toucan_vscp_canal.cpp
+++ b/hardware_integration/src/toucan_vscp_canal.cpp
@@ -15,99 +15,102 @@
 
 #include <thread>
 
-TouCANPlugin::TouCANPlugin(std::int16_t deviceID, std::uint32_t serialNumber, std::uint16_t baudRate)
+namespace isobus
 {
-	std::string deviceConfigString;
-	std::string serialString;
-	constexpr std::uint32_t MAX_SERIAL_LENGTH = 999999999;
-	constexpr std::size_t SERIAL_NUMBER_CHARACTER_REQUIREMENT = 8;
-
-	if (serialNumber > MAX_SERIAL_LENGTH)
+	TouCANPlugin::TouCANPlugin(std::int16_t deviceID, std::uint32_t serialNumber, std::uint16_t baudRate)
 	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TouCAN]: Invalid serial number. Must be 8 digits max.");
-		serialNumber = 0;
-	}
-	serialString = isobus::to_string(serialNumber);
+		std::string deviceConfigString;
+		std::string serialString;
+		constexpr std::uint32_t MAX_SERIAL_LENGTH = 999999999;
+		constexpr std::size_t SERIAL_NUMBER_CHARACTER_REQUIREMENT = 8;
 
-	if (SERIAL_NUMBER_CHARACTER_REQUIREMENT > serialString.length())
+		if (serialNumber > MAX_SERIAL_LENGTH)
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TouCAN]: Invalid serial number. Must be 8 digits max.");
+			serialNumber = 0;
+		}
+		serialString = isobus::to_string(serialNumber);
+
+		if (SERIAL_NUMBER_CHARACTER_REQUIREMENT > serialString.length())
+		{
+			serialString.insert(0, SERIAL_NUMBER_CHARACTER_REQUIREMENT - serialString.length(), '0');
+		}
+
+		deviceConfigString += isobus::to_string(deviceID) + ';';
+		deviceConfigString += serialString + ';';
+		deviceConfigString += isobus::to_string(baudRate) + ';';
+		name = deviceConfigString;
+	}
+
+	TouCANPlugin::TouCANPlugin(std::string deviceName) :
+	  name(deviceName)
 	{
-		serialString.insert(0, SERIAL_NUMBER_CHARACTER_REQUIREMENT - serialString.length(), '0');
 	}
 
-	deviceConfigString += isobus::to_string(deviceID) + ';';
-	deviceConfigString += serialString + ';';
-	deviceConfigString += isobus::to_string(baudRate) + ';';
-	name = deviceConfigString;
-}
-
-TouCANPlugin::TouCANPlugin(std::string deviceName) :
-  name(deviceName)
-{
-}
-
-TouCANPlugin::~TouCANPlugin()
-{
-}
-
-bool TouCANPlugin::get_is_valid() const
-{
-	return (CANAL_ERROR_SUCCESS == openResult);
-}
-
-void TouCANPlugin::close()
-{
-	CanalClose(handle);
-	openResult = CANAL_ERROR_NOT_OPEN;
-}
-
-void TouCANPlugin::open()
-{
-	long tempHandle = CanalOpen(name.c_str(), 0);
-
-	if (-1 != tempHandle)
+	TouCANPlugin::~TouCANPlugin()
 	{
-		handle = tempHandle;
-		openResult = CANAL_ERROR_SUCCESS;
 	}
-	else
+
+	bool TouCANPlugin::get_is_valid() const
 	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TouCAN]: Error trying to connect to TouCAN probe. Check your device ID and serial number.");
+		return (CANAL_ERROR_SUCCESS == openResult);
 	}
-}
 
-bool TouCANPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	long result = CANAL_ERROR_GENERIC;
-	structCanalMsg CANMsg = { 0 };
-
-	result = CanalReceive(handle, &CANMsg);
-
-	if (CANAL_ERROR_SUCCESS == result)
+	void TouCANPlugin::close()
 	{
-		canFrame.dataLength = CANMsg.sizeData;
-		memcpy(canFrame.data, CANMsg.data, sizeof(canFrame.data));
-		canFrame.identifier = CANMsg.id;
-		canFrame.isExtendedFrame = (0 != (CANAL_IDFLAG_EXTENDED & CANMsg.flags));
-		canFrame.timestamp_us = CANMsg.timestamp;
+		CanalClose(handle);
+		openResult = CANAL_ERROR_NOT_OPEN;
 	}
-	else
+
+	void TouCANPlugin::open()
 	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		long tempHandle = CanalOpen(name.c_str(), 0);
+
+		if (-1 != tempHandle)
+		{
+			handle = tempHandle;
+			openResult = CANAL_ERROR_SUCCESS;
+		}
+		else
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TouCAN]: Error trying to connect to TouCAN probe. Check your device ID and serial number.");
+		}
 	}
-	return (CANAL_ERROR_SUCCESS == result);
-}
 
-bool TouCANPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	std::uint32_t result = CANAL_ERROR_SUCCESS;
-	structCanalMsg msgCanMessage;
+	bool TouCANPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
+	{
+		long result = CANAL_ERROR_GENERIC;
+		structCanalMsg CANMsg = { 0 };
 
-	msgCanMessage.id = canFrame.identifier;
-	msgCanMessage.sizeData = canFrame.dataLength;
-	msgCanMessage.flags = canFrame.isExtendedFrame ? CANAL_IDFLAG_EXTENDED : CANAL_IDFLAG_STANDARD;
-	memcpy(msgCanMessage.data, canFrame.data, canFrame.dataLength);
+		result = CanalReceive(handle, &CANMsg);
 
-	result = CanalSend(handle, &msgCanMessage);
+		if (CANAL_ERROR_SUCCESS == result)
+		{
+			canFrame.dataLength = CANMsg.sizeData;
+			memcpy(canFrame.data, CANMsg.data, sizeof(canFrame.data));
+			canFrame.identifier = CANMsg.id;
+			canFrame.isExtendedFrame = (0 != (CANAL_IDFLAG_EXTENDED & CANMsg.flags));
+			canFrame.timestamp_us = CANMsg.timestamp;
+		}
+		else
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		}
+		return (CANAL_ERROR_SUCCESS == result);
+	}
 
-	return (CANAL_ERROR_SUCCESS == result);
+	bool TouCANPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
+	{
+		std::uint32_t result = CANAL_ERROR_SUCCESS;
+		structCanalMsg msgCanMessage;
+
+		msgCanMessage.id = canFrame.identifier;
+		msgCanMessage.sizeData = canFrame.dataLength;
+		msgCanMessage.flags = canFrame.isExtendedFrame ? CANAL_IDFLAG_EXTENDED : CANAL_IDFLAG_STANDARD;
+		memcpy(msgCanMessage.data, canFrame.data, canFrame.dataLength);
+
+		result = CanalSend(handle, &msgCanMessage);
+
+		return (CANAL_ERROR_SUCCESS == result);
+	}
 }

--- a/hardware_integration/src/twai_plugin.cpp
+++ b/hardware_integration/src/twai_plugin.cpp
@@ -19,111 +19,114 @@
 #include <cstring>
 #include <limits>
 
-TWAIPlugin::TWAIPlugin(const twai_general_config_t *generalConfig, const twai_timing_config_t *timingConfig, const twai_filter_config_t *filterConfig) :
-  generalConfig(generalConfig),
-  timingConfig(timingConfig),
-  filterConfig(filterConfig)
+namespace isobus
 {
-}
-
-TWAIPlugin::~TWAIPlugin()
-{
-	close();
-}
-
-bool TWAIPlugin::get_is_valid() const
-{
-	twai_status_info_t status;
-	esp_err_t error = twai_get_status_info(&status);
-	if (ESP_OK == error)
+	TWAIPlugin::TWAIPlugin(const twai_general_config_t *generalConfig, const twai_timing_config_t *timingConfig, const twai_filter_config_t *filterConfig) :
+	  generalConfig(generalConfig),
+	  timingConfig(timingConfig),
+	  filterConfig(filterConfig)
 	{
-		return status.state == TWAI_STATE_RUNNING;
 	}
-	else
-	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error getting status: " + isobus::to_string(esp_err_to_name(error)));
-	}
-	return false;
-}
 
-void TWAIPlugin::close()
-{
-	esp_err_t error = twai_stop();
-	if (ESP_OK != error)
+	TWAIPlugin::~TWAIPlugin()
 	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error stopping driver: " + isobus::to_string(esp_err_to_name(error)));
+		close();
 	}
-	error = twai_driver_uninstall();
-	if (ESP_OK != error)
-	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error uninstalling driver: " + isobus::to_string(esp_err_to_name(error)));
-	}
-}
 
-void TWAIPlugin::open()
-{
-	esp_err_t error = twai_driver_install(generalConfig, timingConfig, filterConfig);
-	if (ESP_OK != error)
+	bool TWAIPlugin::get_is_valid() const
 	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TWAI] Error installing driver: " + isobus::to_string(esp_err_to_name(error)));
-	}
-	error = twai_start();
-	if (ESP_OK != error)
-	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TWAI] Error starting driver: " + isobus::to_string(esp_err_to_name(error)));
-	}
-}
-
-bool TWAIPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	bool retVal = false;
-
-	//Wait for message to be received
-	twai_message_t message;
-	esp_err_t error = twai_receive(&message, portMAX_DELAY);
-	if (ESP_OK == error)
-	{
-		// Process received message
-		if (!(message.rtr))
+		twai_status_info_t status;
+		esp_err_t error = twai_get_status_info(&status);
+		if (ESP_OK == error)
 		{
-			canFrame.identifier = message.identifier;
-			canFrame.isExtendedFrame = message.extd;
-			canFrame.dataLength = message.data_length_code;
-			if (isobus::CAN_DATA_LENGTH >= canFrame.dataLength)
-			{
-				memset(canFrame.data, 0, sizeof(canFrame.data));
-				memcpy(canFrame.data, message.data, canFrame.dataLength);
-				retVal = true;
-			}
+			return status.state == TWAI_STATE_RUNNING;
+		}
+		else
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error getting status: " + isobus::to_string(esp_err_to_name(error)));
+		}
+		return false;
+	}
+
+	void TWAIPlugin::close()
+	{
+		esp_err_t error = twai_stop();
+		if (ESP_OK != error)
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error stopping driver: " + isobus::to_string(esp_err_to_name(error)));
+		}
+		error = twai_driver_uninstall();
+		if (ESP_OK != error)
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error uninstalling driver: " + isobus::to_string(esp_err_to_name(error)));
 		}
 	}
-	else
+
+	void TWAIPlugin::open()
 	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error receiving message: " + isobus::to_string(esp_err_to_name(error)));
+		esp_err_t error = twai_driver_install(generalConfig, timingConfig, filterConfig);
+		if (ESP_OK != error)
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TWAI] Error installing driver: " + isobus::to_string(esp_err_to_name(error)));
+		}
+		error = twai_start();
+		if (ESP_OK != error)
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TWAI] Error starting driver: " + isobus::to_string(esp_err_to_name(error)));
+		}
 	}
 
-	return retVal;
-}
-
-bool TWAIPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
-{
-	bool retVal = false;
-	twai_message_t message;
-
-	message.identifier = canFrame.identifier;
-	message.extd = canFrame.isExtendedFrame;
-	message.data_length_code = canFrame.dataLength;
-	memcpy(message.data, canFrame.data, canFrame.dataLength);
-
-	esp_err_t error = twai_transmit(&message, portMAX_DELAY);
-	if (ESP_OK == error)
+	bool TWAIPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
 	{
-		retVal = true;
+		bool retVal = false;
+
+		//Wait for message to be received
+		twai_message_t message;
+		esp_err_t error = twai_receive(&message, portMAX_DELAY);
+		if (ESP_OK == error)
+		{
+			// Process received message
+			if (!(message.rtr))
+			{
+				canFrame.identifier = message.identifier;
+				canFrame.isExtendedFrame = message.extd;
+				canFrame.dataLength = message.data_length_code;
+				if (isobus::CAN_DATA_LENGTH >= canFrame.dataLength)
+				{
+					memset(canFrame.data, 0, sizeof(canFrame.data));
+					memcpy(canFrame.data, message.data, canFrame.dataLength);
+					retVal = true;
+				}
+			}
+		}
+		else
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error receiving message: " + isobus::to_string(esp_err_to_name(error)));
+		}
+
+		return retVal;
 	}
-	else
+
+	bool TWAIPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
 	{
-		isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error sending message: " + isobus::to_string(esp_err_to_name(error)));
+		bool retVal = false;
+		twai_message_t message;
+
+		message.identifier = canFrame.identifier;
+		message.extd = canFrame.isExtendedFrame;
+		message.data_length_code = canFrame.dataLength;
+		memcpy(message.data, canFrame.data, canFrame.dataLength);
+
+		esp_err_t error = twai_transmit(&message, portMAX_DELAY);
+		if (ESP_OK == error)
+		{
+			retVal = true;
+		}
+		else
+		{
+			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error sending message: " + isobus::to_string(esp_err_to_name(error)));
+		}
+		return retVal;
 	}
-	return retVal;
 }
 #endif // ESP_PLATFORM

--- a/sphinx/source/Tutorials/Adding a Destination.rst
+++ b/sphinx/source/Tutorials/Adding a Destination.rst
@@ -103,7 +103,7 @@ The final program for this tutorial (including the code from the previous Hello 
 
    void signal_handler(int)
    {
-      CANHardwareInterface::stop(); // Clean up the threads
+      isobus::CANHardwareInterface::stop(); // Clean up the threads
 		_exit(EXIT_FAILURE);
    }
 
@@ -114,11 +114,11 @@ The final program for this tutorial (including the code from the previous Hello 
       std::shared_ptr<isobus::PartneredControlFunction> myPartner = nullptr; // A pointer to hold a partner
 
       // Set up the hardware layer to use SocketCAN interface on channel "can0"
-      std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
-      CANHardwareInterface::set_number_of_can_channels(1);
-      CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+      std::shared_ptr<isobus::SocketCANInterface> canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
+      isobus::CANHardwareInterface::set_number_of_can_channels(1);
+      isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-      if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+      if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
       {
          std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
          return -1;
@@ -163,7 +163,7 @@ The final program for this tutorial (including the code from the previous Hello 
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
       // Clean up the threads
-      CANHardwareInterface::stop();
+      isobus::CANHardwareInterface::stop();
 
       return 0;
    }

--- a/sphinx/source/Tutorials/Receiving Messages.rst
+++ b/sphinx/source/Tutorials/Receiving Messages.rst
@@ -79,7 +79,7 @@ So, our updated tutorial program now should look like this:
 
    void signal_handler(int)
    {
-      CANHardwareInterface::stop(); // Clean up the threads
+      isobus::CANHardwareInterface::stop(); // Clean up the threads
 		_exit(EXIT_FAILURE);
    }
 
@@ -99,11 +99,11 @@ So, our updated tutorial program now should look like this:
       std::shared_ptr<isobus::PartneredControlFunction> myPartner = nullptr; // A pointer to hold a partner
 
       // Set up the hardware layer to use SocketCAN interface on channel "can0"
-      std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
-      CANHardwareInterface::set_number_of_can_channels(1);
-      CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+      std::shared_ptr<isobus::SocketCANInterface> canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
+      isobus::CANHardwareInterface::set_number_of_can_channels(1);
+      isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-      if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+      if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
       {
          std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
          return -1;
@@ -155,7 +155,7 @@ So, our updated tutorial program now should look like this:
       }
 
       // Clean up the threads
-      CANHardwareInterface::stop();
+      isobus::CANHardwareInterface::stop();
 
       return 0;
    }

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -176,11 +176,11 @@ There are a few lines we'll need to add:
 
 .. code-block:: c++
 
-   std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
-   CANHardwareInterface::set_number_of_can_channels(1);
-   CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+   std::shared_ptr<isobus::SocketCANInterface> canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
+   isobus::CANHardwareInterface::set_number_of_can_channels(1);
+   isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-   if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+   if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
    {
       std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
       return -1;
@@ -190,15 +190,14 @@ The "CANHardwareInterface" is an independent component that is not actually dire
 
 So, lets talk about what's happening here.
 
-:code:`std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");` Creates a new SocketCANInterface object, and stores it in a shared_ptr. This is the object that will be used to interface with the socket CAN driver.
+:code:`std::shared_ptr<isobus::SocketCANInterface> canDriver = std::make_shared<isobus::SocketCANInterface>("can0");` Creates a new SocketCANInterface object, and stores it in a shared_ptr. This is the object that will be used to interface with the socket CAN driver.
 
-:code:`CANHardwareInterface::set_number_of_can_channels(1)` Is telling the hardware layer (socket CAN in our case) that we will use 1 CAN adapter.
+:code:`isobus::CANHardwareInterface::set_number_of_can_channels(1)` Is telling the hardware layer (socket CAN in our case) that we will use 1 CAN adapter.
 
-:code:`CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);` Tells the hardware layer that we want to use the SocketCANInterface object we just created as the handler for CAN channel 0.
+:code:`isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);` Tells the hardware layer that we want to use the SocketCANInterface object we just created as the handler for CAN channel 0.
 
-:code:`CANHardwareInterface::start();` Kicks off a number of threads that will manage the socket and issue callbacks for when messages are received. It also provides callbacks to 'tick' the stack cyclically.
+:code:`isobus::CANHardwareInterface::start();` Kicks off a number of threads that will manage the socket and issue callbacks for when messages are received. It also provides callbacks to 'tick' the stack cyclically.
 Checking its return value and :code:`get_is_valid` will tell you if the underlying CAN driver is connected to the hardware. In this case, since we're using socket CAN, it tells us if we bound to the socket.
-
 
 Let's see what we've got so far:
 
@@ -218,11 +217,11 @@ Let's see what we've got so far:
       std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
       // Set up the hardware layer to use SocketCAN interface on channel "can0"
-      std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
-      CANHardwareInterface::set_number_of_can_channels(1);
-      CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+      std::shared_ptr<isobus::SocketCANInterface> canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
+      isobus::CANHardwareInterface::set_number_of_can_channels(1);
+      isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-      if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+      if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
       {
          std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
          return -2;
@@ -251,9 +250,9 @@ Sweet! We're almost ready to send a message. Let's just add a few more things to
 Cleaning up
 ------------
 
-Whenever the program ends, we want to call :code:`CANHardwareInterface::stop();` to clean up the hardware layer and stop the threads we started with :code:`CANHardwareInterface::start();`.
+Whenever the program ends, we want to call :code:`isobus::CANHardwareInterface::stop();` to clean up the hardware layer and stop the threads we started with :code:`isobus::CANHardwareInterface::start();`.
 
-Additionally, we want to call :code:`CANHardwareInterface::stop();` if the user presses control+c (user sends a SIGINT signal to our program). So let's add a little signal handler that'll gracefully clean up if that happens.
+Additionally, we want to call :code:`isobus::CANHardwareInterface::stop();` if the user presses control+c (user sends a SIGINT signal to our program). So let's add a little signal handler that'll gracefully clean up if that happens.
 
 Make sure to include `csignal`.
 
@@ -270,7 +269,7 @@ Make sure to include `csignal`.
 
    void signal_handler(int)
    {
-      CANHardwareInterface::stop(); // Clean up the threads
+      isobus::CANHardwareInterface::stop(); // Clean up the threads
 		_exit(EXIT_FAILURE);
    }
 
@@ -280,11 +279,11 @@ Make sure to include `csignal`.
       std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
       // Set up the hardware layer to use SocketCAN interface on channel "can0"
-      std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
-      CANHardwareInterface::set_number_of_can_channels(1);
-      CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+      std::shared_ptr<isobus::SocketCANInterface> canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
+      isobus::CANHardwareInterface::set_number_of_can_channels(1);
+      isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-      if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+      if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
       {
          std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
          return -2;
@@ -309,7 +308,7 @@ Make sure to include `csignal`.
       myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
 
       // Clean up the threads
-      CANHardwareInterface::stop();
+      isobus::CANHardwareInterface::stop();
 
       return 0;
    }
@@ -338,7 +337,7 @@ The total result:
 
    void signal_handler(int)
    {
-   	CANHardwareInterface::stop(); // Clean up the threads
+   	isobus::CANHardwareInterface::stop(); // Clean up the threads
 		_exit(EXIT_FAILURE);
    }
    
@@ -348,11 +347,11 @@ The total result:
     std::shared_ptr<isobus::InternalControlFunction> myECU = nullptr; // A pointer to hold our InternalControlFunction
 
     // Set up the hardware layer to use SocketCAN interface on channel "can0"
-    std::shared_ptr<SocketCANInterface> canDriver = std::make_shared<SocketCANInterface>("can0");
-    CANHardwareInterface::set_number_of_can_channels(1);
-    CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+    std::shared_ptr<isobus::SocketCANInterface> canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
+    isobus::CANHardwareInterface::set_number_of_can_channels(1);
+    isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-    if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+    if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
     {
     	 std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
     	 return -2;
@@ -379,7 +378,7 @@ The total result:
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
     // Clean up the threads
-    CANHardwareInterface::stop();
+    isobus::CANHardwareInterface::stop();
 
     return 0;
    }

--- a/sphinx/source/Tutorials/Virtual Terminal Basics.rst
+++ b/sphinx/source/Tutorials/Virtual Terminal Basics.rst
@@ -70,15 +70,15 @@ Create the file `main.cpp` as shown below inside that folder with the requisite 
 		std::signal(SIGINT, signal_handler);
 
 		// Automatically load the desired CAN driver based on the available drivers
-		std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+		std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 	#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-		canDriver = std::make_shared<SocketCANInterface>("can0");
+		canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 	#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-		canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+		canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 	#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-		canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+		canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 	#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-		canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+		canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 	#endif
 		if (nullptr == canDriver)
 		{
@@ -86,17 +86,17 @@ Create the file `main.cpp` as shown below inside that folder with the requisite 
 			std::cout << "If you want to use a different driver, please add it to the list above." << std::endl;
 			return -1;
 		}
-		CANHardwareInterface::set_number_of_can_channels(1);
-		CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+		isobus::CANHardwareInterface::set_number_of_can_channels(1);
+		isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-		if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+		if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 		{
 			std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 			return -2;
 		}
 
-		CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-		CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
+		isobus::CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
+		isobus::CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(250));
 
@@ -125,7 +125,7 @@ Create the file `main.cpp` as shown below inside that folder with the requisite 
 			std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 		}
 
-		CANHardwareInterface::stop();
+		isobus::CANHardwareInterface::stop();
 		return 0;
 	}
 
@@ -461,15 +461,15 @@ Here's the final code for this example:
 		std::signal(SIGINT, signal_handler);
 
 		// Automatically load the desired CAN driver based on the available drivers
-		std::shared_ptr<CANHardwarePlugin> canDriver = nullptr;
+		std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 	#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-		canDriver = std::make_shared<SocketCANInterface>("can0");
+		canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
 	#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-		canDriver = std::make_shared<PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+		canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 	#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-		canDriver = std::make_shared<InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+		canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
 	#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-		canDriver = std::make_shared<MacCANPCANPlugin>(PCAN_USBBUS1);
+		canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
 	#endif
 		if (nullptr == canDriver)
 		{
@@ -478,17 +478,17 @@ Here's the final code for this example:
 			return -1;
 		}
 
-		CANHardwareInterface::set_number_of_can_channels(1);
-		CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+		isobus::CANHardwareInterface::set_number_of_can_channels(1);
+		isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
 
-		if ((!CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+		if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
 		{
 			std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
 			return -2;
 		}
 
-		CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
-		CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
+		isobus::CANHardwareInterface::add_can_lib_update_callback(update_CAN_network, nullptr);
+		isobus::CANHardwareInterface::add_raw_can_message_rx_callback(raw_can_glue, nullptr);
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(250));
 
@@ -536,7 +536,7 @@ Here's the final code for this example:
 		}
 
 		TestVirtualTerminalClient->terminate();
-		CANHardwareInterface::stop();
+		isobus::CANHardwareInterface::stop();
 		return 0;
 	}
 


### PR DESCRIPTION
This is probably a bit of a breaking change to our hardware plugin api, so it's good to get it out of the way sooner rather than later...

This change brings the hardware integration library under the isobus namespace for consistency. 
Previously it was in the global namespace, which is probably not ideal as described in #197.

Originally the idea was to have the hardware interface be completely separate and optional for the library, so I didn't want to put it in the same namespace, but these days it's pretty well entangled with the library and makes using it a lot easier, so might as well get it out of the global namespace.

I am open to comments if people think this is not the way to go.

Closes #197 