### PR TITLE
[Core]: Add busload calculation

### DIFF
--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -293,6 +293,7 @@ namespace isobus
 						if (transmit_can_message_from_buffer(frame))
 						{
 							frameTransmittedEventDispatcher.invoke(std::move(frame));
+							isobus::on_transmit_can_message_frame_from_hardware(frame);
 							channel->messagesToBeTransmitted.pop_front();
 						}
 						else

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -27,6 +27,7 @@ set(ISOBUS_SRC
     "can_stack_logger.cpp"
     "can_network_configuration.cpp"
     "can_callbacks.cpp"
+    "can_frame.cpp"
     "isobus_virtual_terminal_client.cpp"
     "can_extended_transport_protocol.cpp"
     "isobus_diagnostic_protocol.cpp"

--- a/isobus/include/isobus/isobus/can_frame.hpp
+++ b/isobus/include/isobus/isobus/can_frame.hpp
@@ -22,6 +22,10 @@ namespace isobus
 	class HardwareInterfaceCANFrame
 	{
 	public:
+		/// Returns the number of bits in a CAN message with averaged bit stuffing
+		/// @returns The number of bits in the message (with average bit stuffing)
+		std::uint32_t get_number_bits_in_message() const;
+
 		std::uint64_t timestamp_us; ///< A microsecond timestamp
 		std::uint32_t identifier; ///< The 32 bit identifier of the frame
 		std::uint8_t channel; ///< The CAN channel index associated with the frame

--- a/isobus/include/isobus/isobus/can_hardware_abstraction.hpp
+++ b/isobus/include/isobus/isobus/can_hardware_abstraction.hpp
@@ -24,6 +24,10 @@ namespace isobus
 	/// @param[in] frame The frame to receive from the hardware
 	void receive_can_message_frame_from_hardware(const HardwareInterfaceCANFrame &frame);
 
+	/// @brief Informs the network manager whenever messages are emitted on the bus
+	/// @param[in] txFrame The CAN frame that was just emitted
+	void on_transmit_can_message_frame_from_hardware(const HardwareInterfaceCANFrame &txFrame);
+
 	/// @brief The periodic update abstraction layer between the hardware and the stack
 	void periodic_update_from_hardware();
 

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -188,12 +188,6 @@ namespace isobus
 		/// @brief Constructor for the network manager. Sets default values for members
 		CANNetworkManager();
 
-		/// Returns the number of bits in a CAN message with averaged bit stuffing
-		/// @param[in] numberDataBytes The number of bytes in the data payload of the message
-		/// @param[in] messageType The frame type (extended or standard ID)
-		/// @returns The number of bits in the message (with average bit stuffing)
-		static std::uint32_t get_number_bits_in_message(std::uint8_t numberDataBytes, CANIdentifier::Type messageType);
-
 		/// @brief Updates the internal address table based on a received CAN message
 		/// @param[in] message A message being received by the stack
 		void update_address_table(CANMessage &message);
@@ -203,9 +197,10 @@ namespace isobus
 		/// @param[in] claimedAddress The address claimed
 		void update_address_table(std::uint8_t CANPort, std::uint8_t claimedAddress);
 
-		/// @brief Processes a CAN message's contribution to the current bus load
-		/// @param[in] message The message to process
-		void update_busload(const CANMessage &message);
+		/// @brief Processes a CAN message's contribution to the current busload
+		/// @param[in] channelIndex The CAN channel index associated to the message being processed
+		/// @param[in] numberOfBitsProcessed The number of bits to add to the busload calculation
+		void update_busload(std::uint8_t channelIndex, std::uint32_t numberOfBitsProcessed);
 
 		/// @brief Updates the stored bit accumulators for calculating the bus load over a multiple sample windows
 		void update_busload_history();

--- a/isobus/src/can_frame.cpp
+++ b/isobus/src/can_frame.cpp
@@ -1,0 +1,35 @@
+//================================================================================================
+/// @file can_frame.cpp
+///
+/// @brief Implements helper functions for HardwareInterfaceCANFrame
+/// @author Adrian Del Grosso
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
+#include "isobus/isobus/can_frame.hpp"
+#include "isobus/isobus/can_constants.hpp"
+#include "isobus/isobus/can_identifier.hpp"
+
+namespace isobus
+{
+	std::uint32_t HardwareInterfaceCANFrame::get_number_bits_in_message() const
+	{
+		constexpr std::uint32_t MAX_CONSECUTIVE_SAME_BITS = 5; // After 5 consecutive bits, 6th will be opposite
+		const std::uint32_t dataLengthBits = CAN_DATA_LENGTH * dataLength;
+		std::uint32_t retVal = 0;
+
+		if (isExtendedFrame)
+		{
+			constexpr std::uint32_t EXTENDED_ID_BEST_NON_DATA_LENGTH = 67; // SOF, ID, Control, CRC, ACK, EOF, and interframe space
+			constexpr std::uint32_t EXTENDED_ID_WORST_NON_DATA_LENGTH = 78;
+			retVal = ((dataLengthBits + EXTENDED_ID_BEST_NON_DATA_LENGTH) + (dataLengthBits + (dataLengthBits / MAX_CONSECUTIVE_SAME_BITS) + EXTENDED_ID_WORST_NON_DATA_LENGTH));
+		}
+		else
+		{
+			constexpr std::uint32_t STANDARD_ID_BEST_NON_DATA_LENGTH = 47; // SOF, ID, Control, CRC, ACK, EOF, and interframe space
+			constexpr std::uint32_t STANDARD_ID_WORST_NON_DATA_LENGTH = 54;
+			retVal = ((dataLengthBits + STANDARD_ID_BEST_NON_DATA_LENGTH) + (dataLengthBits + (dataLengthBits / MAX_CONSECUTIVE_SAME_BITS) + STANDARD_ID_WORST_NON_DATA_LENGTH));
+		}
+		return retVal / 2;
+	}
+} // namespace isobus

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -419,7 +419,7 @@ namespace isobus
 			constexpr std::uint32_t STANDARD_ID_WORST_NON_DATA_LENGTH = 54;
 			retVal = ((dataLengthBits + STANDARD_ID_BEST_NON_DATA_LENGTH) + (dataLengthBits + (dataLengthBits / MAX_CONSECUTIVE_SAME_BITS) + STANDARD_ID_WORST_NON_DATA_LENGTH));
 		}
-		return retVal;
+		return retVal / 2;
 	}
 
 	void CANNetworkManager::update_address_table(CANMessage &message)
@@ -510,6 +510,7 @@ namespace isobus
 				{
 					busloadMessageBitsHistory.at(i).pop_front();
 				}
+				currentBusloadBitAccumulator.at(i) = 0;
 			}
 			busloadUpdateTimestamp_ms = SystemTiming::get_timestamp_ms();
 		}

--- a/test/core_network_management_tests.cpp
+++ b/test/core_network_management_tests.cpp
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
 
 #include "isobus/isobus/can_internal_control_function.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_partnered_control_function.hpp"
 
 #include <memory>
+#include <thread>
 
 using namespace isobus;
 
@@ -35,4 +37,36 @@ TEST(CORE_TESTS, TestCreateAndDestroyICFs)
 	auto TestIcf2 = new isobus::InternalControlFunction(TestDeviceNAME, 0x80, 0);
 	delete TestIcf2;
 	auto TestIcf3 = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x81, 0);
+}
+
+TEST(CORE_TESTS, BusloadTest)
+{
+	EXPECT_EQ(0.0f, CANNetworkManager::CANNetwork.get_estimated_busload(0)); // This test runs early in the testing, so load should be zero.
+	EXPECT_EQ(0.0f, CANNetworkManager::CANNetwork.get_estimated_busload(200)); // Invalid channel should return zero load
+
+	// Send a bunch of messages through the receive process
+	HardwareInterfaceCANFrame testFrame;
+	testFrame.dataLength = 8;
+	testFrame.channel = 0;
+	testFrame.isExtendedFrame = true;
+	testFrame.identifier = 0x18EFFFFE;
+	memset(testFrame.data, 0, sizeof(testFrame.data));
+
+	CANNetworkManager::CANNetwork.update(); // Make sure the network manager is initialized
+	for (std::uint_fast8_t i = 0; i < 25; i++)
+	{
+		CANNetworkManager::process_receive_can_message_frame(testFrame); // Send a bunch of junk messages
+	}
+	testFrame.isExtendedFrame = false;
+	testFrame.identifier = 0x7F;
+	for (std::uint_fast8_t i = 0; i < 25; i++)
+	{
+		CANNetworkManager::process_receive_can_message_frame(testFrame); // Send a bunch of junk messages
+	}
+	std::this_thread::sleep_for(std::chrono::milliseconds(101));
+	CANNetworkManager::CANNetwork.update();
+
+	// Bus load should be non zero, and less than 100%
+	EXPECT_NE(0.0f, CANNetworkManager::CANNetwork.get_estimated_busload(0));
+	EXPECT_LT(CANNetworkManager::CANNetwork.get_estimated_busload(0), 100.0f);
 }


### PR DESCRIPTION
* Now the network manager will calculate the estimated busload over a rolling 1s time window using ten 100ms sample windows. 
* The average of best and worst case bit stuffing is used to approximate the load. 
* Also, I added some functionality to the hardware interface to tell the network manager whenever messages are emitted onto the bus. Both Tx and Rx messages must be considered to get a reasonably accurate bus load estimation.

Any sustained bus load > 70% should be considered potentially unstable. Perhaps we should log warnings in this case?
