### PR TITLE
[VT]: Added some additional getters to the VT client

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -242,6 +242,34 @@ namespace isobus
 			ReservedRemoveAssignment = 31 ///< Used for Remove assignment command
 		};
 
+		/// @brief The internal state machine state of the VT client, mostly just public so tests can access it
+		enum class StateMachineState : std::uint8_t
+		{
+			Disconnected, ///< VT is not connected, and is not trying to connect yet
+			WaitForPartnerVTStatusMessage, ///< VT client is initialized, waiting for a VT server to come online
+			SendWorkingSetMasterMessage, ///< Client is sending the working state master message
+			ReadyForObjectPool, ///< Client needs an object pool before connection can continue
+			SendGetMemory, ///< Client is sending the "get memory" message to see if VT has enough memory available
+			WaitForGetMemoryResponse, ///< Client is waiting for a response to the "get memory" message
+			SendGetNumberSoftkeys, ///< Client is sending the "get number of soft keys" message
+			WaitForGetNumberSoftKeysResponse, ///< Client is waiting for a response to the "get number of soft keys" message
+			SendGetTextFontData, ///< Client is sending the "get text font data" message
+			WaitForGetTextFontDataResponse, ///< Client is waiting for a response to the "get text font data" message
+			SendGetHardware, ///< Client is sending the "get hardware" message
+			WaitForGetHardwareResponse, ///< Client is waiting for a response to the "get hardware" message
+			SendGetVersions, ///< If a version label was specified, check to see if the VT has that version already
+			WaitForGetVersionsResponse, ///< Client is waiting for a response to the "get versions" message
+			SendStoreVersion, ///< Sending the store version command
+			WaitForStoreVersionResponse, ///< Client is waiting for a response to the store version command
+			SendLoadVersion, ///< Sending the load version command
+			WaitForLoadVersionResponse, ///< Client is waiting for the VT to respond to the "Load Version" command
+			UploadObjectPool, ///< Client is uploading the object pool
+			SendEndOfObjectPool, ///< Client is sending the end of object pool message
+			WaitForEndOfObjectPoolResponse, ///< Client is waiting for the end of object pool response message
+			Connected, ///< Client is connected to the VT server and the application layer is in control
+			Failed ///< Client could not connect to the VT due to an error
+		};
+
 		/// @brief A struct for storing information of a function assigned to an auxiliary input
 		class AssignedAuxiliaryFunction
 		{
@@ -291,6 +319,18 @@ namespace isobus
 		// Calling this will stop the worker thread if it exists
 		/// @brief Terminates the client and joins the worker thread if applicable
 		void terminate();
+
+		/// @brief Returns the partner control function being used by the client
+		/// @returns The partner control function being used by the client
+		std::shared_ptr<PartneredControlFunction> get_partner_control_function() const;
+
+		/// @brief Returns the internal control function being used by the client
+		/// @returns The internal control function being used by the client
+		std::shared_ptr<InternalControlFunction> get_internal_control_function() const;
+
+		/// @brief Returns the active working set master's address
+		/// @returns The active working set master's address, or 0xFE (NULL_CAN_ADDRESS) if none or unknown
+		std::uint8_t get_active_working_set_master_address() const;
 
 		/// @brief A struct for storing information of a VT key input event
 		struct VTKeyEvent
@@ -1144,34 +1184,6 @@ namespace isobus
 		LanguageCommandInterface languageCommandInterface;
 
 	protected:
-		/// @brief The internal state machine state of the VT client
-		enum class StateMachineState : std::uint8_t
-		{
-			Disconnected, ///< VT is not connected, and is not trying to connect yet
-			WaitForPartnerVTStatusMessage, ///< VT client is initialized, waiting for a VT server to come online
-			SendWorkingSetMasterMessage, ///< Client is sending the working state master message
-			ReadyForObjectPool, ///< Client needs an object pool before connection can continue
-			SendGetMemory, ///< Client is sending the "get memory" message to see if VT has enough memory available
-			WaitForGetMemoryResponse, ///< Client is waiting for a response to the "get memory" message
-			SendGetNumberSoftkeys, ///< Client is sending the "get number of soft keys" message
-			WaitForGetNumberSoftKeysResponse, ///< Client is waiting for a response to the "get number of soft keys" message
-			SendGetTextFontData, ///< Client is sending the "get text font data" message
-			WaitForGetTextFontDataResponse, ///< Client is waiting for a response to the "get text font data" message
-			SendGetHardware, ///< Client is sending the "get hardware" message
-			WaitForGetHardwareResponse, ///< Client is waiting for a response to the "get hardware" message
-			SendGetVersions, ///< If a version label was specified, check to see if the VT has that version already
-			WaitForGetVersionsResponse, ///< Client is waiting for a response to the "get versions" message
-			SendStoreVersion, ///< Sending the store version command
-			WaitForStoreVersionResponse, ///< Client is waiting for a response to the store version command
-			SendLoadVersion, ///< Sending the load version command
-			WaitForLoadVersionResponse, ///< Client is waiting for the VT to respond to the "Load Version" command
-			UploadObjectPool, ///< Client is uploading the object pool
-			SendEndOfObjectPool, ///< Client is sending the end of object pool message
-			WaitForEndOfObjectPoolResponse, ///< Client is waiting for the end of object pool response message
-			Connected, ///< Client is connected to the VT server and the application layer is in control
-			Failed ///< Client could not connect to the VT due to an error
-		};
-
 		/// @brief Enumerates the multiplexor byte values for VT commands
 		enum class Function : std::uint8_t
 		{

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -320,8 +320,8 @@ namespace isobus
 		/// @brief Terminates the client and joins the worker thread if applicable
 		void terminate();
 
-		/// @brief Returns the partner control function being used by the client
-		/// @returns The partner control function being used by the client
+		/// @brief Returns the control function of the VT server with which this VT client communicates.
+		/// @returns The partner control function for the VT server
 		std::shared_ptr<PartneredControlFunction> get_partner_control_function() const;
 
 		/// @brief Returns the internal control function being used by the client

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -131,6 +131,27 @@ namespace isobus
 		}
 	}
 
+	std::shared_ptr<PartneredControlFunction> VirtualTerminalClient::get_partner_control_function() const
+	{
+		return partnerControlFunction;
+	}
+
+	std::shared_ptr<InternalControlFunction> VirtualTerminalClient::get_internal_control_function() const
+	{
+		return myControlFunction;
+	}
+
+	std::uint8_t VirtualTerminalClient::get_active_working_set_master_address() const
+	{
+		std::uint8_t retVal = NULL_CAN_ADDRESS;
+
+		if (get_is_connected())
+		{
+			retVal = activeWorkingSetMasterAddress;
+		}
+		return retVal;
+	}
+
 	std::shared_ptr<void> VirtualTerminalClient::add_vt_soft_key_event_listener(std::function<void(const VTKeyEvent &)> callback)
 	{
 		return softKeyEventDispatcher.add_listener(callback);

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -66,6 +66,11 @@ public:
 		largeFontSizesBitfield = largeFontsBitfield;
 	}
 
+	void test_wrapper_set_state(VirtualTerminalClient::StateMachineState value)
+	{
+		VirtualTerminalClient::set_state(value);
+	}
+
 	static std::vector<std::uint8_t> staticTestPool;
 
 	static bool testWrapperDataChunkCallback(std::uint32_t,
@@ -110,6 +115,9 @@ TEST(VIRTUAL_TERMINAL_TESTS, InitializeAndInitialState)
 	EXPECT_EQ(0, clientUnderTest.get_number_x_pixels());
 	EXPECT_EQ(VirtualTerminalClient::VTVersion::ReservedOrUnknown, clientUnderTest.get_connected_vt_version());
 
+	EXPECT_NE(nullptr, clientUnderTest.get_internal_control_function());
+	EXPECT_NE(nullptr, clientUnderTest.get_partner_control_function());
+
 	clientUnderTest.terminate();
 }
 
@@ -149,6 +157,11 @@ TEST(VIRTUAL_TERMINAL_TESTS, VTStatusMessage)
 
 	EXPECT_EQ(1234, clientUnderTest.get_visible_data_mask());
 	EXPECT_EQ(4567, clientUnderTest.get_visible_soft_key_mask());
+	EXPECT_EQ(0xFE, clientUnderTest.get_active_working_set_master_address()); // Expect null address since not in the connected state
+
+	// Test the master address is correct when in the connected state
+	clientUnderTest.test_wrapper_set_state(VirtualTerminalClient::StateMachineState::Connected);
+	EXPECT_EQ(0x26, clientUnderTest.get_active_working_set_master_address());
 }
 
 TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithVector)


### PR DESCRIPTION
- Added getters for the VT's control functions.
- Added a way to get the active working set master's address as reported by the VT server. 
- Added unit tests for these new functions, which required making the state machine states public similar to the TC client implementation.