### PR TITLE
[ISB]: Add support for ISOBUS shortcut button (ISB)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,8 @@ if(BUILD_TESTING)
       test/language_command_interface_tests.cpp
       test/tc_client_tests.cpp
       test/ddop_tests.cpp
-      test/event_dispatcher_tests.cpp)
+      test/event_dispatcher_tests.cpp
+      test/isb_tests.cpp)
 
   add_executable(unit_tests ${TEST_SRC})
   target_link_libraries(

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -36,7 +36,8 @@ set(ISOBUS_SRC
     "isobus_language_command_interface.cpp"
     "isobus_task_controller_client_objects.cpp"
     "isobus_task_controller_client.cpp"
-    "isobus_device_descriptor_object_pool.cpp")
+    "isobus_device_descriptor_object_pool.cpp"
+    "isobus_shortcut_button_interface.cpp")
 
 # Prepend the source directory path to all the source files
 prepend(ISOBUS_SRC ${ISOBUS_SRC_DIR} ${ISOBUS_SRC})
@@ -72,7 +73,8 @@ set(ISOBUS_INCLUDE
     "isobus_standard_data_description_indices.hpp"
     "isobus_task_controller_client_objects.hpp"
     "isobus_task_controller_client.hpp"
-    "isobus_device_descriptor_object_pool.hpp")
+    "isobus_device_descriptor_object_pool.hpp"
+    "isobus_shortcut_button_interface.hpp")
 
 # Prepend the include directory path to all the include files
 prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})

--- a/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
@@ -39,7 +39,8 @@ namespace isobus
 		DiagnosticMessage2 = 0xFECB,
 		DiagnosticMessage3 = 0xFECC,
 		DiagnosticMessage11 = 0xFED3,
-		SoftwareIdentification = 0xFEDA
+		SoftwareIdentification = 0xFEDA,
+		AllImplementsStopOperationsSwitchState = 0xFD02
 	};
 
 } // namespace isobus

--- a/isobus/include/isobus/isobus/isobus_shortcut_button_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_shortcut_button_interface.hpp
@@ -79,10 +79,10 @@ namespace isobus
 		/// @brief Destructor for a ShortcutButtonInterface
 		virtual ~ShortcutButtonInterface();
 
-		/// @brief Adds a callback that will get called when any CF commands a stop to implement operations
-		/// and likewise will be called again when all tracked CFs are sending the "permit implement operations" state
-		/// @param[in] callback The callback to add
-		std::shared_ptr<void> add_stop_all_implement_operations_state_callback(std::function<void(StopAllImplementOperationsState ISBState)> callback);
+		/// @brief Gets the event dispatcher for when the assigned bus' ISB state changes.
+		/// The assigned bus is determined by which internal control function you pass into the constructor.
+		/// @returns The event dispatcher which can be used to register callbacks/listeners to
+		EventDispatcher<StopAllImplementOperationsState> &get_stop_all_implement_operations_state_event_dispatcher();
 
 		/// @brief Sets the state that the interface will broadcast on the bus.
 		/// @note This is only used when the interface was created as a server.

--- a/isobus/include/isobus/isobus/isobus_shortcut_button_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_shortcut_button_interface.hpp
@@ -1,0 +1,169 @@
+//================================================================================================
+/// @file isobus_shortcut_button_interface.hpp
+///
+/// @brief Defines an interface for communicating as or from an ISOBUS shortcut button (ISB).
+/// Defined in AEF Guideline 004 - ISB and at https://www.isobus.net/isobus/pGNAndSPN/10936
+/// (ISO 11783-7)
+///
+/// @details This interfaces manages the PGN used by isobus shortcut buttons (ISB).
+/// You can choose to either receive this message, send it, or both. An ISB is essentially
+/// a command to all implements to enter a safe state. See the description located at
+/// https://www.isobus.net/isobus/pGNAndSPN/10936, ISO 11783-7, or
+/// https://www.aef-online.org/fileadmin/user_upload/Content/pdfs/AEF_One_Pager.pdf
+/// for more details.
+///
+/// @attention If you consume this message, you MUST implement an associated alarm in your
+/// VT/UT object pool, along with an icon or other indication on your home screen that your
+/// working set master supports ISB, as required for AEF conformance.
+///
+/// @author Adrian Del Grosso
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
+#ifndef ISOBUS_SHORTCUT_BUTTON_INTERFACE_HPP
+#define ISOBUS_SHORTCUT_BUTTON_INTERFACE_HPP
+
+#include "isobus/isobus/can_NAME.hpp"
+#include "isobus/isobus/can_internal_control_function.hpp"
+#include "isobus/isobus/can_message.hpp"
+#include "isobus/isobus/can_protocol.hpp"
+#include "isobus/utility/event_dispatcher.hpp"
+#include "isobus/utility/processing_flags.hpp"
+
+#include <array>
+#include <functional>
+#include <list>
+#include <memory>
+
+namespace isobus
+{
+	/// @brief An interface for communicating as or interpreting the messages of ISOBUS Shortcut Buttons
+	/// @details This interface parses the "All implements stop operations switch state" message
+	/// that is sent by ISOBUS shortcut buttons, and also allows you to optionally transmit the same message
+	/// as an ISOBUS shortcut button.
+	///
+	/// This message may be sent by any control function connected to the implement bus on forestry or
+	/// agriculture implements providing to connected systems the current state of the all implement stop operations switch.
+	/// At least one of these switches shall be in each operator location of the connected system.
+	///
+	/// All implements shall start a process to stop all operations when this broadcast message is received from any CF
+	/// with a value of "Stop implement operations" (SPN 5140). Before an implement turns off all implement operations,
+	/// it shall assume a failsafe condition. If an implement is operating in an automation mode,
+	/// it may enter a failsafe condition before requesting the tractor ECU to exit the automation mode,
+	/// e.g. PTO, Auxiliary valve, and/or tractor movement.
+	///
+	/// The working set master for the implement shall then inform the operator that the implement has stopped
+	/// all operations due to the activation of the Stop All Implement Operations switch.
+	/// Implement working set masters shall include, on their home screen, an indication,
+	/// e.g. icon or a function name, if it supports Stop All Implement Operations.
+	/// The Working Set shall monitor the number of transitions for each ISB server upon receiving first
+	/// the message from a given ISB server. A Working Set shall consider an increase in the transitions
+	/// without detecting a corresponding transition of the Stop all implement operations state as an error and react accordingly.
+	class ShortcutButtonInterface : public CANLibProtocol
+	{
+	public:
+		/// @brief Enumerates the states that can be sent in the main ISB message (pgn 64770, 0xFD02)
+		enum class StopAllImplementOperationsState : std::uint8_t
+		{
+			StopImplementOperations = 0, ///< Stop implement operations
+			PermitAllImplementsToOperationOn = 1, ///< Permit all implements to operation ON
+			Error = 2, ///< Error indication
+			NotAvailable = 3 ///< Not available
+		};
+
+		/// @brief Constructor for a ShortcutButtonInterface
+		/// @param[in] internalControlFunction The InternalControlFunction that the interface will use to send messages (not nullptr)
+		/// @param[in] serverEnabled Enables the interface's transmission of the "Stop all implement operations" message.
+		ShortcutButtonInterface(std::shared_ptr<InternalControlFunction> internalControlFunction, bool serverEnabled = false);
+
+		/// @brief Destructor for a ShortcutButtonInterface
+		virtual ~ShortcutButtonInterface();
+
+		/// @brief Adds a callback that will get called when any CF commands a stop to implement operations
+		/// and likewise will be called again when all tracked CFs are sending the "permit implement operations" state
+		/// @param[in] callback The callback to add
+		std::shared_ptr<void> add_stop_all_implement_operations_state_callback(std::function<void(StopAllImplementOperationsState ISBState)> callback);
+
+		/// @brief Sets the state that the interface will broadcast on the bus.
+		/// @note This is only used when the interface was created as a server.
+		/// @param[in] newState The state to broadcast on the bus if the interface is a server
+		void set_stop_all_implement_operations_state(StopAllImplementOperationsState newState);
+
+		/// @brief Returns the current ISB state for the bus, which is a combination of the internal commanded
+		/// state and the states reported by all other CFs.
+		/// @returns The current ISB state for the bus associated with the interface's internal control function
+		StopAllImplementOperationsState get_state();
+
+		/// @brief The network manager calls this to see if the protocol can accept a non-raw CAN message for processing
+		/// @returns true if the message was accepted by the protocol for processing
+		bool protocol_transmit_message(std::uint32_t,
+		                               const std::uint8_t *,
+		                               std::uint32_t,
+		                               ControlFunction *,
+		                               ControlFunction *,
+		                               TransmitCompleteCallback,
+		                               void *,
+		                               DataChunkCallback) override;
+
+		/// @brief This will be called by the network manager on every cyclic update of the stack
+		void update(CANLibBadge<CANNetworkManager>) override;
+
+	private:
+		/// @brief Stores data about a sender of the stop all implement operations switch state
+		class ISBServerData
+		{
+		public:
+			/// @brief Constructor for ISBServerData, sets default values
+			ISBServerData() = default;
+
+			NAME ISONAME; ///< The ISONAME of the sender, used as a lookup key
+			StopAllImplementOperationsState commandedState; ///< The last state we received from this ISB
+			std::uint32_t messageReceivedTimestamp_ms = 0; ///< Tracks the last time we received a message from this ISB so we can time them out if needed
+			std::uint8_t stopAllImplementOperationsTransitionNumber = 0; ///< Number of transitions from Permit (01) to Stop (00) since power up of the stop all implement operations parameter
+		};
+
+		/// @brief Enumerates a set of flags that the interface uses to know if it should transmit a message
+		enum class TransmitFlags : std::uint32_t
+		{
+			SendStopAllImplementOperationsSwitchState = 0, ///< A flag to send the main ISB message
+
+			NumberOfFlags ///< The number of flags defined in this enumeration
+		};
+
+		/// @brief Parses incoming CAN messages for the interface
+		/// @param message The CAN message to parse
+		/// @param parentPointer A generic context variable, usually the `this` pointer for this interface instance
+		static void process_rx_message(CANMessage *message, void *parentPointer);
+
+		/// @brief Processes the internal Tx flags
+		/// @param[in] flag The flag to process
+		/// @param[in] parent A context variable to find the relevant interface class
+		static void process_flags(std::uint32_t flag, void *parent);
+
+		/// @brief A generic way to initialize a protocol
+		/// @details The network manager will call a protocol's initialize function
+		/// when it is first updated, if it has yet to be initialized.
+		void initialize(CANLibBadge<CANNetworkManager>) override;
+
+		/// @brief A generic way for a protocol to process a received message
+		/// @param[in] message A received CAN message
+		void process_message(CANMessage *const message) override;
+
+		/// @brief Sends the Stop all implement operations switch state message
+		/// @returns true if the message was sent, otherwise false
+		bool send_stop_all_implement_operations_switch_state() const;
+
+		static constexpr std::uint32_t TRANSMISSION_RATE_MS = 1000; ///< The cyclic transmission time for PGN 0xFD02
+		static constexpr std::uint32_t TRANSMISSION_TIMEOUT_MS = 3000; ///< Amount of time between messages until we consider an ISB stale (arbitrary, but similar to VT timeout)
+
+		std::list<ISBServerData> isobusShorcutButtonList; ///< A list of all senders of the ISB messages used to track transition counts
+		std::shared_ptr<InternalControlFunction> sourceControlFunction = nullptr; ///< The internal control function that the interface is assigned to and will use to transmit
+		EventDispatcher<StopAllImplementOperationsState> ISBEventDispatcher; ///< Manages callbacks about ISB states
+		ProcessingFlags txFlags; ///< A set of flags to manage retries while sending messages
+		std::uint32_t allImplementsStopOperationsSwitchStateTimestamp_ms = 0; ///< A timestamp to track the need for cyclic transmission of PGN 0xFD02
+		std::uint8_t stopAllImplementOperationsTransitionNumber = 0; ///< A counter used to track our transitions from "stop" to "permit" when acting as a server
+		StopAllImplementOperationsState commandedState = StopAllImplementOperationsState::NotAvailable; ///< The state set by the user to transmit if we're acting as a server
+		bool actAsISBServer = false; ///< A setting that enables sending the ISB messages rather than just receiving them
+	};
+} // namespace isobus
+#endif // ISOBUS_SHORTCUT_BUTTON_INTERFACE_HPP

--- a/isobus/src/isobus_shortcut_button_interface.cpp
+++ b/isobus/src/isobus_shortcut_button_interface.cpp
@@ -35,9 +35,9 @@ namespace isobus
 		}
 	}
 
-	std::shared_ptr<void> ShortcutButtonInterface::add_stop_all_implement_operations_state_callback(std::function<void(StopAllImplementOperationsState ISBState)> callback)
+	EventDispatcher<ShortcutButtonInterface::StopAllImplementOperationsState> &ShortcutButtonInterface::get_stop_all_implement_operations_state_event_dispatcher()
 	{
-		return ISBEventDispatcher.add_listener(callback);
+		return ISBEventDispatcher;
 	}
 
 	void ShortcutButtonInterface::set_stop_all_implement_operations_state(StopAllImplementOperationsState newState)

--- a/isobus/src/isobus_shortcut_button_interface.cpp
+++ b/isobus/src/isobus_shortcut_button_interface.cpp
@@ -1,0 +1,241 @@
+//================================================================================================
+/// @file isobus_shortcut_button_interface.cpp
+///
+/// @brief Implements the interface for an ISOBUS shortcut button
+/// @author Adrian Del Grosso
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
+#include "isobus/isobus/isobus_shortcut_button_interface.hpp"
+
+#include "isobus/isobus/can_constants.hpp"
+#include "isobus/isobus/can_general_parameter_group_numbers.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
+#include "isobus/isobus/can_stack_logger.hpp"
+#include "isobus/utility/system_timing.hpp"
+
+#include <algorithm>
+#include <cassert>
+
+namespace isobus
+{
+	ShortcutButtonInterface::ShortcutButtonInterface(std::shared_ptr<InternalControlFunction> internalControlFunction, bool serverEnabled) :
+	  sourceControlFunction(internalControlFunction),
+	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberOfFlags), process_flags, this),
+	  actAsISBServer(serverEnabled)
+	{
+		assert(nullptr != sourceControlFunction); // You need an internal control function for the interface to function
+	}
+
+	ShortcutButtonInterface::~ShortcutButtonInterface()
+	{
+		if (initialized)
+		{
+			CANNetworkManager::CANNetwork.remove_global_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AllImplementsStopOperationsSwitchState), process_rx_message, this);
+		}
+	}
+
+	std::shared_ptr<void> ShortcutButtonInterface::add_stop_all_implement_operations_state_callback(std::function<void(StopAllImplementOperationsState ISBState)> callback)
+	{
+		return ISBEventDispatcher.add_listener(callback);
+	}
+
+	void ShortcutButtonInterface::set_stop_all_implement_operations_state(StopAllImplementOperationsState newState)
+	{
+		if (actAsISBServer)
+		{
+			if (newState != commandedState)
+			{
+				commandedState = newState;
+
+				if (StopAllImplementOperationsState::StopImplementOperations == newState)
+				{
+					CANStackLogger::error("[ISB]: All implement operations must stop. (Triggered internally)");
+				}
+				else
+				{
+					CANStackLogger::info("[ISB]: Internal ISB state is now permitted.");
+				}
+				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::SendStopAllImplementOperationsSwitchState));
+			}
+		}
+		else
+		{
+			CANStackLogger::error("[ISB]: You are attempting to set the internal ISB state but the ISB interface is not configured as a server!");
+		}
+	}
+
+	ShortcutButtonInterface::StopAllImplementOperationsState ShortcutButtonInterface::get_state()
+	{
+		StopAllImplementOperationsState retVal = StopAllImplementOperationsState::PermitAllImplementsToOperationOn;
+
+		if (StopAllImplementOperationsState::StopImplementOperations == commandedState)
+		{
+			retVal = commandedState;
+		}
+		else
+		{
+			for (auto ISB = isobusShorcutButtonList.cbegin(); ISB != isobusShorcutButtonList.end(); ISB++)
+			{
+				if (StopAllImplementOperationsState::StopImplementOperations == ISB->commandedState)
+				{
+					retVal = ISB->commandedState; // Any stop condition will be returned.
+					break;
+				}
+			}
+		}
+		return retVal;
+	}
+
+	bool ShortcutButtonInterface::protocol_transmit_message(std::uint32_t,
+	                                                        const std::uint8_t *,
+	                                                        std::uint32_t,
+	                                                        ControlFunction *,
+	                                                        ControlFunction *,
+	                                                        TransmitCompleteCallback,
+	                                                        void *,
+	                                                        DataChunkCallback)
+	{
+		return false;
+	}
+
+	void ShortcutButtonInterface::update(CANLibBadge<CANNetworkManager>)
+	{
+		if (SystemTiming::time_expired_ms(allImplementsStopOperationsSwitchStateTimestamp_ms, TRANSMISSION_RATE_MS))
+		{
+			// Prune old ISBs
+			isobusShorcutButtonList.erase(std::remove_if(isobusShorcutButtonList.begin(), isobusShorcutButtonList.end(), [](ISBServerData &isb) {
+				                              return SystemTiming::time_expired_ms(isb.messageReceivedTimestamp_ms, TRANSMISSION_TIMEOUT_MS);
+			                              }),
+			                              isobusShorcutButtonList.end());
+
+			txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::SendStopAllImplementOperationsSwitchState));
+		}
+		txFlags.process_all_flags();
+	}
+
+	void ShortcutButtonInterface::process_rx_message(CANMessage *message, void *parentPointer)
+	{
+		assert(nullptr != message);
+		assert(nullptr != parentPointer);
+
+		static_cast<ShortcutButtonInterface *>(parentPointer)->process_message(message);
+	}
+
+	void ShortcutButtonInterface::process_flags(std::uint32_t flag, void *parent)
+	{
+		auto myInterface = static_cast<ShortcutButtonInterface *>(parent);
+		bool transmitSuccessful = true;
+		assert(nullptr != parent);
+
+		if (flag == static_cast<std::uint32_t>(TransmitFlags::SendStopAllImplementOperationsSwitchState))
+		{
+			transmitSuccessful = myInterface->send_stop_all_implement_operations_switch_state();
+
+			if (transmitSuccessful)
+			{
+				myInterface->stopAllImplementOperationsTransitionNumber++;
+			}
+		}
+
+		if (!transmitSuccessful)
+		{
+			myInterface->txFlags.set_flag(flag);
+		}
+	}
+
+	void ShortcutButtonInterface::initialize(CANLibBadge<CANNetworkManager>)
+	{
+		CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AllImplementsStopOperationsSwitchState),
+		                                                                         process_rx_message,
+		                                                                         this);
+		initialized = true;
+	}
+
+	void ShortcutButtonInterface::process_message(CANMessage *const message)
+	{
+		if ((message->get_can_port_index() == sourceControlFunction->get_can_port()) &&
+		    (static_cast<std::uint32_t>(CANLibParameterGroupNumber::AllImplementsStopOperationsSwitchState) == message->get_identifier().get_parameter_group_number()))
+		{
+			if (CAN_DATA_LENGTH == message->get_data_length())
+			{
+				auto messageNAME = message->get_source_control_function()->get_NAME();
+				auto matches_isoname = [messageNAME](ISBServerData &isb) { return isb.ISONAME == messageNAME; };
+				auto ISB = std::find_if(isobusShorcutButtonList.begin(), isobusShorcutButtonList.end(), matches_isoname);
+				auto &messageData = message->get_data();
+				StopAllImplementOperationsState previousState = get_state();
+
+				if (isobusShorcutButtonList.end() == ISB)
+				{
+					ISBServerData newISB;
+
+					CANStackLogger::debug("[ISB]: New ISB detected at address %u", message->get_identifier().get_source_address());
+					newISB.ISONAME = messageNAME;
+					isobusShorcutButtonList.emplace_back(newISB);
+					ISB = std::prev(isobusShorcutButtonList.end());
+				}
+
+				if (isobusShorcutButtonList.end() != ISB)
+				{
+					std::uint8_t newTransitionCount = messageData.at(6);
+
+					if (((ISB->stopAllImplementOperationsTransitionNumber == 255) &&
+					     (0 != newTransitionCount)) ||
+					    ((ISB->stopAllImplementOperationsTransitionNumber < 255) &&
+					     (newTransitionCount > ISB->stopAllImplementOperationsTransitionNumber + 1)))
+					{
+						// A Working Set shall consider an increase in the transitions without detecting a corresponding
+						// transition of the Stop all implement operations state as an error and react accordingly.
+						ISB->commandedState = StopAllImplementOperationsState::StopImplementOperations;
+						CANStackLogger::error("[ISB]: Missed an ISB transition from ISB at address %u", message->get_identifier().get_source_address());
+					}
+					else
+					{
+						ISB->commandedState = static_cast<StopAllImplementOperationsState>(messageData.at(7) & 0x03);
+					}
+					ISB->messageReceivedTimestamp_ms = SystemTiming::get_timestamp_ms();
+					ISB->stopAllImplementOperationsTransitionNumber = messageData.at(6);
+
+					auto newState = get_state();
+					if (previousState != newState)
+					{
+						if (StopAllImplementOperationsState::StopImplementOperations == newState)
+						{
+							CANStackLogger::error("[ISB]: All implement operations must stop. (ISB at address %u has commanded it)", message->get_identifier().get_source_address());
+						}
+						else
+						{
+							CANStackLogger::info("[ISB]: Implement operations now permitted.");
+						}
+						ISBEventDispatcher.invoke(std::move(newState));
+					}
+				}
+			}
+			else
+			{
+				CANStackLogger::warn("[ISB]: Received malformed All Implements Stop Operations Switch State. DLC must be 8.");
+			}
+		}
+	}
+
+	bool ShortcutButtonInterface::send_stop_all_implement_operations_switch_state() const
+	{
+		std::array<std::uint8_t, CAN_DATA_LENGTH> buffer = {
+			0xFF,
+			0xFF,
+			0xFF,
+			0xFF,
+			0xFF,
+			0xFF,
+			stopAllImplementOperationsTransitionNumber,
+			static_cast<std::uint8_t>(0xFC | static_cast<std::uint8_t>(commandedState))
+		};
+
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AllImplementsStopOperationsSwitchState),
+		                                                      buffer.data(),
+		                                                      buffer.size(),
+		                                                      sourceControlFunction.get(),
+		                                                      nullptr,
+		                                                      CANIdentifier::Priority3);
+	}
+}

--- a/test/isb_tests.cpp
+++ b/test/isb_tests.cpp
@@ -203,7 +203,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
 
-	auto testEvent = interfaceUnderTest.add_stop_all_implement_operations_state_callback(testCallback);
+	auto testEvent = interfaceUnderTest.get_stop_all_implement_operations_state_event_dispatcher().add_listener(testCallback);
 
 	// Test callback
 	// Set up to test roll over at 255
@@ -224,6 +224,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	std::this_thread::sleep_for(std::chrono::milliseconds(3100));
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	CANHardwareInterface::stop();
 }
 
 TEST(ISB_TESTS, ShortcutButtonTxTests)
@@ -300,4 +301,6 @@ TEST(ISB_TESTS, ShortcutButtonTxTests)
 	EXPECT_EQ(testFrame.data[7], 0xFC);
 
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+
+	CANHardwareInterface::stop();
 }

--- a/test/isb_tests.cpp
+++ b/test/isb_tests.cpp
@@ -1,0 +1,303 @@
+#include <gtest/gtest.h>
+
+#include "isobus/hardware_integration/can_hardware_interface.hpp"
+#include "isobus/hardware_integration/virtual_can_plugin.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
+#include "isobus/isobus/isobus_shortcut_button_interface.hpp"
+#include "isobus/utility/system_timing.hpp"
+
+using namespace isobus;
+
+static ShortcutButtonInterface::StopAllImplementOperationsState lastCallbackValue = ShortcutButtonInterface::StopAllImplementOperationsState::Error;
+
+static void testCallback(ShortcutButtonInterface::StopAllImplementOperationsState testState)
+{
+	lastCallbackValue = testState;
+}
+
+TEST(ISB_TESTS, ShortcutButtonRxTests)
+{
+	VirtualCANPlugin serverPlugin;
+	serverPlugin.open();
+
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
+	CANHardwareInterface::start();
+
+	NAME clientNAME(0);
+	clientNAME.set_industry_group(2);
+	clientNAME.set_ecu_instance(4);
+	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::RateControl));
+	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x97, 0);
+
+	HardwareInterfaceCANFrame testFrame;
+
+	// Force claim some other ECU
+	testFrame.dataLength = 8;
+	testFrame.channel = 0;
+	testFrame.isExtendedFrame = true;
+	testFrame.identifier = 0x18EEFF74;
+	testFrame.data[0] = 0x03;
+	testFrame.data[1] = 0x04;
+	testFrame.data[2] = 0x00;
+	testFrame.data[3] = 0x13;
+	testFrame.data[4] = 0x00;
+	testFrame.data[5] = 0x83;
+	testFrame.data[6] = 0x00;
+	testFrame.data[7] = 0xA0;
+
+	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
+
+	while ((!internalECU->get_address_valid()) &&
+	       (!SystemTiming::time_expired_ms(waitingTimestamp_ms, 2000)))
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	// Get the virtual CAN plugin back to a known state
+	while (!serverPlugin.get_queue_empty())
+	{
+		serverPlugin.read_frame(testFrame);
+	}
+	ASSERT_TRUE(serverPlugin.get_queue_empty());
+	ASSERT_TRUE(internalECU->get_address_valid());
+	// End boilerplate **********************************
+
+	ShortcutButtonInterface interfaceUnderTest(internalECU, false);
+	EXPECT_EQ(false, interfaceUnderTest.get_is_initialized());
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(true, interfaceUnderTest.get_is_initialized());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+
+	// Since we're not acting as a server, make sure the public setter doesn't do anything
+	interfaceUnderTest.set_stop_all_implement_operations_state(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations);
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+
+	// Send a valid message to stop
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0x00;
+	testFrame.data[7] = 0x00;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+
+	// Set back to permit state
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0x01;
+	testFrame.data[7] = 0x01;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+
+	// Send increased, incorrect transition count
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0x08;
+	testFrame.data[7] = 0x01;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+
+	// Test reset of state as counter is back to normal
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0x09;
+	testFrame.data[7] = 0x01;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+
+	// Test reset to zero counter, which should be fine
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0x00;
+	testFrame.data[7] = 0x01;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+
+	// Test state as counter is back to normal
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0x01;
+	testFrame.data[7] = 0x01;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+
+	// Set up to test roll over at 255
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0xFE;
+	testFrame.data[7] = 0x01;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+	// Go to 255
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0xFF;
+	testFrame.data[7] = 0x01;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+
+	// Rollover should stay at "permit"
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0x00;
+	testFrame.data[7] = 0x01;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+
+	auto testEvent = interfaceUnderTest.add_stop_all_implement_operations_state_callback(testCallback);
+
+	// Test callback
+	// Set up to test roll over at 255
+	testFrame.identifier = 0x18FD0274;
+	testFrame.data[0] = 0xFF;
+	testFrame.data[1] = 0xFF;
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0xF0;
+	testFrame.data[7] = 0x00;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, lastCallbackValue);
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(3100));
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+}
+
+TEST(ISB_TESTS, ShortcutButtonTxTests)
+{
+	VirtualCANPlugin serverPlugin;
+	serverPlugin.open();
+
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
+	CANHardwareInterface::start();
+
+	NAME clientNAME(0);
+	clientNAME.set_industry_group(2);
+	clientNAME.set_ecu_instance(4);
+	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::RateControl));
+	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x98, 0);
+
+	HardwareInterfaceCANFrame testFrame;
+
+	// Force claim some other ECU
+	testFrame.dataLength = 8;
+	testFrame.channel = 0;
+	testFrame.isExtendedFrame = true;
+	testFrame.identifier = 0x18EEFF74;
+	testFrame.data[0] = 0x03;
+	testFrame.data[1] = 0x04;
+	testFrame.data[2] = 0x00;
+	testFrame.data[3] = 0x13;
+	testFrame.data[4] = 0x00;
+	testFrame.data[5] = 0x83;
+	testFrame.data[6] = 0x00;
+	testFrame.data[7] = 0xA0;
+
+	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
+
+	while ((!internalECU->get_address_valid()) &&
+	       (!SystemTiming::time_expired_ms(waitingTimestamp_ms, 2000)))
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	// Get the virtual CAN plugin back to a known state
+	while (!serverPlugin.get_queue_empty())
+	{
+		serverPlugin.read_frame(testFrame);
+	}
+	ASSERT_TRUE(serverPlugin.get_queue_empty());
+	ASSERT_TRUE(internalECU->get_address_valid());
+	// End boilerplate **********************************
+
+	ShortcutButtonInterface interfaceUnderTest(internalECU, true);
+	CANNetworkManager::CANNetwork.update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+
+	interfaceUnderTest.set_stop_all_implement_operations_state(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations);
+	CANNetworkManager::CANNetwork.update();
+	serverPlugin.read_frame(testFrame);
+	serverPlugin.read_frame(testFrame);
+
+	ASSERT_TRUE(testFrame.isExtendedFrame);
+	ASSERT_EQ(testFrame.dataLength, 8);
+	EXPECT_EQ(CANIdentifier(testFrame.identifier).get_parameter_group_number(), 0xFD02);
+	EXPECT_EQ(testFrame.data[0], 0xFF);
+	EXPECT_EQ(testFrame.data[1], 0xFF);
+	EXPECT_EQ(testFrame.data[2], 0xFF);
+	EXPECT_EQ(testFrame.data[3], 0xFF);
+	EXPECT_EQ(testFrame.data[4], 0xFF);
+	EXPECT_EQ(testFrame.data[5], 0xFF);
+	EXPECT_EQ(testFrame.data[6], 0x01);
+	EXPECT_EQ(testFrame.data[7], 0xFC);
+
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+}


### PR DESCRIPTION
* Added support for the AEF ISOBUS shortcut button, including sending as an ISB, and receiving states from other ISBs.

An ISB is essentially a command to all implements to enter a safe state. See the description located at https://www.isobus.net/isobus/pGNAndSPN/10936, ISO 11783-7, or https://www.aef-online.org/fileadmin/user_upload/Content/pdfs/AEF_One_Pager.pdf for more details.