### PR TITLE
[HW]: Initialize twai can message with zero values

### DIFF
--- a/hardware_integration/src/twai_plugin.cpp
+++ b/hardware_integration/src/twai_plugin.cpp
@@ -81,7 +81,7 @@ namespace isobus
 		bool retVal = false;
 
 		//Wait for message to be received
-		twai_message_t message;
+		twai_message_t message = {};
 		esp_err_t error = twai_receive(&message, pdMS_TO_TICKS(1000));
 		if (ESP_OK == error)
 		{
@@ -110,7 +110,7 @@ namespace isobus
 	bool TWAIPlugin::write_frame(const isobus::HardwareInterfaceCANFrame &canFrame)
 	{
 		bool retVal = false;
-		twai_message_t message;
+		twai_message_t message = {};
 
 		message.identifier = canFrame.identifier;
 		message.extd = canFrame.isExtendedFrame;


### PR DESCRIPTION
As mentioned in https://github.com/ad3154/Isobus-plus-plus/discussions/229#discussioncomment-5660508, we want to initialize the members of the TWAI can message struct to their defaults. I think this PR should do the job. Even though I don't know if it makes any difference as it was using fine for me before, I think it is safer to zero-out the struct nonetheless. 