### PR TITLE
[DP]: Add ISOBUS Control Function Functionalities Message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,8 @@ if(BUILD_TESTING)
       test/tc_client_tests.cpp
       test/ddop_tests.cpp
       test/event_dispatcher_tests.cpp
-      test/isb_tests.cpp)
+      test/isb_tests.cpp
+      test/cf_functionalities_tests.cpp)
 
   add_executable(unit_tests ${TEST_SRC})
   target_link_libraries(

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -79,24 +79,32 @@ int main()
 	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC2(567, isobus::DiagnosticProtocol::FailureModeIdentifier::DataErratic, isobus::DiagnosticProtocol::LampStatus::AmberWarningLampSlowFlash);
 	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC3(8910, isobus::DiagnosticProtocol::FailureModeIdentifier::BadIntellegentDevice, isobus::DiagnosticProtocol::LampStatus::RedStopLampSolid);
 
-	// Set a product identification string (in case someone requests it)
-	diagnosticProtocol->set_product_identification_code("1234567890ABC");
-	diagnosticProtocol->set_product_identification_brand("Del Grosso Engineering");
-	diagnosticProtocol->set_product_identification_model("Isobus++ CAN Stack DP Example");
-
-	// Set a software ID string (This is what tells other ECUs what version your software is)
-	diagnosticProtocol->set_software_id_field(0, "Diagnostic Protocol Example 1.0.0");
-	diagnosticProtocol->set_software_id_field(1, "Another version string x.x.x.x");
-
-	// Set an ECU ID (This is what tells other ECUs more details about your specific physical ECU)
-	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::HardwareID, "Hardware ID");
-	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::Location, "The Aether");
-	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::ManufacturerName, "None");
-	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::PartNumber, "1234");
-	diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::SerialNumber, "1");
-
 	if (nullptr != diagnosticProtocol)
 	{
+		// Set a product identification string (in case someone requests it)
+		diagnosticProtocol->set_product_identification_code("1234567890ABC");
+		diagnosticProtocol->set_product_identification_brand("Del Grosso Engineering");
+		diagnosticProtocol->set_product_identification_model("Isobus++ CAN Stack DP Example");
+
+		// Set a software ID string (This is what tells other ECUs what version your software is)
+		diagnosticProtocol->set_software_id_field(0, "Diagnostic Protocol Example 1.0.0");
+		diagnosticProtocol->set_software_id_field(1, "Another version string x.x.x.x");
+
+		// Set an ECU ID (This is what tells other ECUs more details about your specific physical ECU)
+		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::HardwareID, "Hardware ID");
+		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::Location, "The Aether");
+		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::ManufacturerName, "None");
+		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::PartNumber, "1234");
+		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::SerialNumber, "1");
+
+		// Let's say that our ECU has the capability of a universal terminal working set (as an example) and
+		// contains weak internal bus termination.
+		// This info gets reported to any ECU on the bus that requests our capabilities through the
+		// control function functionalities message.
+		diagnosticProtocol->ControlFunctionFunctionalitiesMessageInterface.set_functionality_is_supported(isobus::ControlFunctionFunctionalities::Functionalities::MinimumControlFunction, 1, true);
+		diagnosticProtocol->ControlFunctionFunctionalitiesMessageInterface.set_minimum_control_function_option_state(isobus::ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination, true);
+		diagnosticProtocol->ControlFunctionFunctionalitiesMessageInterface.set_functionality_is_supported(isobus::ControlFunctionFunctionalities::Functionalities::UniversalTerminalWorkingSet, 1, true);
+
 		// Set the DTCs active. This should put them in the DM1 message
 		diagnosticProtocol->set_diagnostic_trouble_code_active(testDTC1, true);
 		diagnosticProtocol->set_diagnostic_trouble_code_active(testDTC2, true);

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -37,7 +37,8 @@ set(ISOBUS_SRC
     "isobus_task_controller_client_objects.cpp"
     "isobus_task_controller_client.cpp"
     "isobus_device_descriptor_object_pool.cpp"
-    "isobus_shortcut_button_interface.cpp")
+    "isobus_shortcut_button_interface.cpp"
+    "isobus_functionalities.cpp")
 
 # Prepend the source directory path to all the source files
 prepend(ISOBUS_SRC ${ISOBUS_SRC_DIR} ${ISOBUS_SRC})
@@ -74,7 +75,8 @@ set(ISOBUS_INCLUDE
     "isobus_task_controller_client_objects.hpp"
     "isobus_task_controller_client.hpp"
     "isobus_device_descriptor_object_pool.hpp"
-    "isobus_shortcut_button_interface.hpp")
+    "isobus_shortcut_button_interface.hpp"
+    "isobus_functionalities.hpp")
 
 # Prepend the include directory path to all the include files
 prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})

--- a/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
@@ -31,6 +31,7 @@ namespace isobus
 		AddressClaim = 0xEE00,
 		ProprietaryA = 0xEF00,
 		ProductIdentification = 0xFC8D,
+		ControlFunctionFunctionalities = 0xFC8E,
 		DiagnosticProtocolIdentification = 0xFD32,
 		WorkingSetMaster = 0xFE0D,
 		LanguageCommand = 0xFE0F,

--- a/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
@@ -38,6 +38,7 @@
 
 #include "isobus/isobus/can_internal_control_function.hpp"
 #include "isobus/isobus/can_protocol.hpp"
+#include "isobus/isobus/isobus_functionalities.hpp"
 #include "isobus/utility/processing_flags.hpp"
 
 #include <array>
@@ -240,6 +241,13 @@ namespace isobus
 		/// @brief Returns `true` if the protocol is in J1939 mode instead of ISO11783 mode, `false` if using ISO11783 mode
 		/// @returns `true` if the protocol is in J1939 mode instead of ISO11783 mode, `false` if using ISO11783 mode
 		bool get_j1939_mode() const;
+
+		/// @brief Use this interface to configure your CF's functionalities.
+		/// This info will be reported to any ECU that requests it and you are
+		/// required to support it on an ISOBUS.
+		/// @note By default, this interface will only report that your ECU is a
+		/// "Minimum Control Function".
+		ControlFunctionFunctionalities ControlFunctionFunctionalitiesMessageInterface;
 
 		/// @brief Clears the list of active DTCs and makes them all inactive
 		void clear_active_diagnostic_trouble_codes();

--- a/isobus/include/isobus/isobus/isobus_functionalities.hpp
+++ b/isobus/include/isobus/isobus/isobus_functionalities.hpp
@@ -25,7 +25,7 @@
 namespace isobus
 {
 	/// @brief Manages the control function functionalities message
-	class ControlFunctionFunctionalities : public CANLibProtocol
+	class ControlFunctionFunctionalities
 	{
 	public:
 		/// @brief Enumerates the different functionalities that an ISOBUS ECU can report
@@ -168,7 +168,7 @@ namespace isobus
 		/// @param[in] functionality The functionality to change
 		/// @param[in] functionalityGeneration The generation of the functionality to report
 		/// @param[in] isSupported If true, this class will add reporting as such on the ISOBUS. If false, it will not be reported on the bus.
-		/// @note Minimum Control Function is enabled by defualt, and generally should not be disabled.
+		/// @note Minimum Control Function is enabled by default, and generally should not be disabled.
 		void set_functionality_is_supported(Functionalities functionality, std::uint8_t functionalityGeneration, bool isSupported);
 
 		/// @brief Returns if a functionality was previously configured with set_functionality_is_supported
@@ -370,19 +370,9 @@ namespace isobus
 		/// @returns true if the aux valve you specified is being reported as "supported".
 		bool get_tractor_implement_management_client_aux_valve_flow_supported(std::uint8_t auxValveIndex);
 
-		/// @brief The network manager calls this to see if the protocol can accept a non-raw CAN message for processing
-		/// @returns true if the message was accepted by the protocol for processing
-		bool protocol_transmit_message(std::uint32_t,
-		                               const std::uint8_t *,
-		                               std::uint32_t,
-		                               ControlFunction *,
-		                               ControlFunction *,
-		                               TransmitCompleteCallback,
-		                               void *,
-		                               DataChunkCallback) override;
-
-		/// @brief This will be called by the network manager on every cyclic update of the stack
-		void update(CANLibBadge<CANNetworkManager>) override;
+		/// @brief This will be called by the network manager when the diagnostic protocol updates.
+		/// There is no need for you to call it manually.
+		void update();
 
 	protected:
 		/// @brief Populates a vector with the message data needed to send PGN 0xFC8E
@@ -417,7 +407,7 @@ namespace isobus
 			/// @returns The state of the requested bit
 			bool get_bit_in_option(std::uint8_t byteIndex, std::uint8_t bit);
 
-			Functionalities functionality = Functionalities::MinimumControlFunction; ///< The funcionalty associated with this data
+			Functionalities functionality = Functionalities::MinimumControlFunction; ///< The functionality associated with this data
 			std::vector<std::uint8_t> serializedValue; ///< The raw message data value for this functionality
 			std::uint8_t generation = 1; ///< The generation of the functionality supported
 		};
@@ -430,11 +420,11 @@ namespace isobus
 			NumberOfFlags ///< The number of flags enumerated in this enum
 		};
 
-		/// @brief Checks for the existance of a functionality in the list of previously configured functionalities
+		/// @brief Checks for the existence of a functionality in the list of previously configured functionalities
 		/// and returns an iterator to that functionality in the list
 		/// @param[in] functionalityToRetreive The functionality to return
 		/// @returns Iterator to the desired functionality, or supportedFunctionalities.end() if not found
-		std::list<FunctionalityData>::iterator get_functionality(Functionalities functionalityToRetreive);
+		std::list<FunctionalityData>::iterator get_functionality(Functionalities functionalityToRetrieve);
 
 		/// @brief A wrapper to to get an option from the first byte of a functionalities' data
 		/// @param[in] functionality The functionality associated to the option being retrieved
@@ -454,10 +444,6 @@ namespace isobus
 		/// @param[in] option The option for which you want to know the bit index into the TIM functionality message data
 		/// @returns The bit offset/index of the specified option int the TIM functionality message data
 		std::uint8_t get_tim_option_bit_index(TractorImplementManagementOptions option) const;
-
-		/// @brief A generic way for a protocol to process a received message
-		/// @param[in] message A received CAN message
-		void process_message(CANMessage *const message) override;
 
 		/// @brief Handles PGN requests for the control function functionalities message
 		/// @param[in] parameterGroupNumber The PGN that was requested

--- a/isobus/include/isobus/isobus/isobus_functionalities.hpp
+++ b/isobus/include/isobus/isobus/isobus_functionalities.hpp
@@ -1,0 +1,236 @@
+//================================================================================================
+/// @file isobus_functionalities.hpp
+///
+/// @brief Defines a class that manages the control function functionalities message data.
+/// (PGN 64654, 0xFC8E) as defined in ISO11783-12
+///
+/// @details The parameters defined here can be found at https://www.isobus.net/isobus/option
+///
+/// @author Adrian Del Grosso
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
+#ifndef ISOBUS_FUNCTIONALITIES_HPP
+#define ISOBUS_FUNCTIONALITIES_HPP
+
+#include "isobus/isobus/can_internal_control_function.hpp"
+
+#include <list>
+#include <mutex>
+#include <vector>
+
+namespace isobus
+{
+	/// @brief Manages the control function functionalities message
+	class ControlFunctionFunctionalities
+	{
+	public:
+		/// @brief Enumerates the different functionalities that an ISOBUS ECU can report
+		/// in the control function functionalities message.
+		enum class Functionalities : std::uint8_t
+		{
+			MinimumControlFunction = 0,
+			UniversalTerminalServer = 1,
+			UniversalTerminalWorkingSet = 2,
+			AuxOInputs = 3,
+			AuxOFunctions = 4,
+			AuxNInputs = 5,
+			AuxNFunctions = 6,
+			TaskControllerBasicServer = 7,
+			TaskControllerBasicClient = 8,
+			TaskControllerGeoServer = 9,
+			TaskControllerGeoClient = 10,
+			TaskControllerSectionControlServer = 11,
+			TaskControllerSectionControlClient = 12,
+			BasicTractorECUServer = 13,
+			BasicTractorECUImplementClient = 14,
+			TractorImplementManagementServer = 15,
+			TractorImplementManagementClient = 16,
+			FileServer = 17,
+			FileServerClient = 18,
+
+			ReservedRangeBegin = 19,
+			MaxFunctionalityReserved = 255
+		};
+
+		/// @brief This parameter reports which minimum control function functionality options are supported.
+		enum class MinimumControlFunctionOptions : std::uint8_t
+		{
+			NoOptions = 0x00,
+			Type1ECUInternalWeakTermination = 0x01,
+			Type2ECUInternalEndPointTermination = 0x02,
+			SupportOfHeartbeatProducer = 0x04,
+			SupportOfHeartbeatConsumer = 0x08,
+
+			Reserved = 0xF0
+		};
+
+		/// @brief This parameter reports which auxiliary control type 1 functionality type functions are supported by
+		/// an implement working set auxiliary function or an auxiliary function input unit.
+		enum class AuxOOptions : std::uint8_t
+		{
+			NoOptions = 0x00,
+			SupportsType0Function = 0x01,
+			SupportsType1Function = 0x02,
+			SupportsType2Function = 0x04,
+
+			Reserved = 0xF8
+		};
+
+		/// @brief This parameter reports which auxiliary control type 2 functionality type functions are supported by
+		// an implement working set auxiliary function or an auxiliary function input unit.
+		enum class AuxNOptions : std::uint16_t
+		{
+			NoOptions = 0x00,
+			SupportsType0Function = 0x01,
+			SupportsType1Function = 0x02,
+			SupportsType2Function = 0x04,
+			SupportsType3Function = 0x08,
+			SupportsType4Function = 0x10,
+			SupportsType5Function = 0x20,
+			SupportsType6Function = 0x40,
+			SupportsType7Function = 0x80,
+			SupportsType8Function = 0x100,
+			SupportsType9Function = 0x200,
+			SupportsType10Function = 0x400,
+			SupportsType11Function = 0x800,
+			SupportsType12Function = 0x1000,
+			SupportsType13Function = 0x2000,
+			SupportsType14Function = 0x4000,
+
+			Reserved = 0x8000
+		};
+
+		/// @brief This option byte reports which task controller geo functionality options are supported by an
+		/// implement working set master or a task controller.
+		enum class TaskControllerGeoServerOptions : std::uint8_t
+		{
+			NoOptions = 0x00,
+			PolygonBasedPrescriptionMapsAreSupported = 0x01,
+
+			Reserved = 0xFE
+		};
+
+		/// @brief This parameter reports which tractor ECU class and functionality options are supported by an implement
+		/// working set master or a tractor ECU.
+		enum class BasicTractorECUOptions : std::uint8_t
+		{
+			TECUNotMeetingCompleteClass1Requirements = 0x00,
+			Class1NoOptions = 0x01,
+			Class2NoOptions = 0x02,
+			ClassRequiredLighting = 0x04,
+			NavigationOption = 0x08,
+			FrontHitchOption = 0x10,
+			GuidanceOption = 0x20,
+			Reserved = 0xC0
+		};
+
+		/// @brief This parameter reports which TIM options are supported by a TIM server or an implement
+		/// working set master
+		enum class TractorImplementManagementOptions
+		{
+			NoOptions,
+			FrontPTODisengagementIsSupported,
+			FrontPTOEngagementCCWIsSupported,
+			FrontPTOengagementCWIsSupported,
+			FrontPTOspeedCCWIsSupported,
+			FrontPTOspeedCWIsSupported,
+			RearPTODisengagementIsSupported,
+			RearPTOEngagementCCWIsSupported,
+			RearPTOEngagementCWIsSupported,
+			RearPTOSpeedCCWIsSupported,
+			RearPTOSpeedCWIsSupported,
+			FrontHitchMotionIsSupported,
+			FrontHitchPositionIsSupported,
+			RearHitchMotionIsSupported,
+			RearHitchPositionIsSupported,
+			VehicleSpeedInForwardDirectionIsSupported,
+			VehicleSpeedInReverseDirectionIsSupported,
+			VehicleSpeedStartMotionIsSupported,
+			VehicleSpeedStopMotionIsSupported,
+			VehicleSpeedForwardSetByServerIsSupported,
+			VehicleSpeedReverseSetByServerIsSupported,
+			VehicleSpeedChangeDirectionIsSupported,
+			GuidanceCurvatureIsSupported
+		};
+
+		/// @brief Constructor for a ControlFunctionFunctionalities object
+		/// @param[in] sourceControlFunction The control function to use when sending messages
+		explicit ControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction);
+
+		/// @brief Adds or removes a supported functionality
+		/// @param[in] functionality The functionality to change
+		/// @param[in] functionalityGeneration The generation of the functionality to report
+		/// @param[in] isSupported If true, this class will add reporting as such on the ISOBUS. If false, it will not be reported on the bus.
+		/// @note Minimum Control Function is enabled by defualt, and generally should not be disabled.
+		void set_functionality_is_supported(Functionalities functionality, std::uint8_t functionalityGeneration, bool isSupported);
+
+		bool get_functionality_is_supported(Functionalities functionality);
+
+		std::uint8_t get_functionality_generation(Functionalities functionality);
+
+		void set_minimum_control_function_option_state(MinimumControlFunctionOptions option, bool optionState);
+
+		void set_aux_O_inputs_option_state(AuxOOptions option, bool optionState);
+		void set_aux_O_functions_option_state(AuxOOptions option, bool optionState);
+		void set_aux_N_inputs_option_state(AuxNOptions option, bool optionState);
+		void set_aux_N_functions_option_state(AuxNOptions option, bool optionState);
+		void set_task_controller_geo_server_option_state(TaskControllerGeoServerOptions option, bool optionState);
+		void set_task_controller_geo_client_option(std::uint8_t numberOfControlChannels);
+		void set_task_controller_section_control_server_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections, bool optionState);
+		void set_task_controller_section_control_client_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections, bool optionState);
+		void set_basic_tractor_ECU_server_option_state(BasicTractorECUOptions option, bool optionState);
+		void set_basic_tractor_ECU_implement_client_option_state(BasicTractorECUOptions option, bool optionState);
+		void set_tractor_implement_management_server_option_state(TractorImplementManagementOptions option, bool optionState);
+		void set_tractor_implement_management_server_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported);
+		void set_tractor_implement_management_client_option_state(TractorImplementManagementOptions option, bool optionState);
+		void set_tractor_implement_management_client_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported);
+
+	private:
+		/// @brief Stores the raw byte data associated with a functionality based on
+		/// what the user has enabled and what options the user has set for that functionality.
+		class FunctionalityData
+		{
+		public:
+			/// @brief Constructor for a FunctionalityData object
+			/// @param[in] functionalityToStore The ISO functionality that the object will represent
+			explicit FunctionalityData(Functionalities functionalityToStore);
+
+			/// @brief Sets up default data associated to the functionality the object is representing
+			/// @details This sets up the serializedValue to be a valid "no options" default set of bytes.
+			void configure_default_data();
+
+			/// @brief A helper function to set a particular option bit to some value within an option byte
+			/// @note If the parameters are out of range, the data will not be modified
+			/// @param[in] byteIndex The options byte index inside which the bit should be set
+			/// @param[in] bit The bit offset index of the bit you want to set, between 0 and 7
+			/// @param[in] value The new value for the desired bit
+			void set_bit_in_option(std::uint8_t byteIndex, std::uint8_t bit, bool value);
+
+			Functionalities functionality = Functionalities::MinimumControlFunction; ///< The funcionalty associated with this data
+			std::vector<std::uint8_t> serializedValue; ///< The raw message data value for this functionality
+			std::uint8_t generation = 1; ///< The generation of the functionality supported
+		};
+
+		/// @brief Checks for the existance of a functionality in the list of previously configured functionalities
+		/// and returns an iterator to that functionality in the list
+		/// @param[in] functionalityToRetreive The functionality to return
+		/// @returns Iterator to the desired functionality, or supportedFunctionalities.end() if not found
+		std::list<FunctionalityData>::iterator get_functionality(Functionalities functionalityToRetreive);
+
+		/// @brief Populates a vector with the message data needed to send PGN 0xFC8E
+		/// @param[in,out] messageData The buffer to populate with data (will be cleared before use)
+		void get_message_content(std::vector<std::uint8_t> &messageData);
+
+		std::uint8_t get_tim_option_byte_index(TractorImplementManagementOptions option) const;
+
+		std::uint8_t get_tim_option_bit_index(TractorImplementManagementOptions option) const;
+
+		static constexpr std::uint8_t NUMBER_TIM_AUX_VALVES_PER_BYTE = 4;
+
+		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The control function to send messages as
+		std::list<FunctionalityData> supportedFunctionalities; ///< A list of all configured functionalities and their data
+		std::mutex functionalitiesMutex; ///< Since messages come in on a different thread than the main app (probably), this mutex protects the functionality data
+	};
+} // namespace isobus
+#endif // ISOBUS_FUNCTIONALITIES_HPP

--- a/isobus/include/isobus/isobus/isobus_functionalities.hpp
+++ b/isobus/include/isobus/isobus/isobus_functionalities.hpp
@@ -14,6 +14,9 @@
 #define ISOBUS_FUNCTIONALITIES_HPP
 
 #include "isobus/isobus/can_internal_control_function.hpp"
+#include "isobus/isobus/can_parameter_group_number_request_protocol.hpp"
+#include "isobus/isobus/can_protocol.hpp"
+#include "isobus/utility/processing_flags.hpp"
 
 #include <list>
 #include <mutex>
@@ -22,7 +25,7 @@
 namespace isobus
 {
 	/// @brief Manages the control function functionalities message
-	class ControlFunctionFunctionalities
+	class ControlFunctionFunctionalities : public CANLibProtocol
 	{
 	public:
 		/// @brief Enumerates the different functionalities that an ISOBUS ECU can report
@@ -129,7 +132,7 @@ namespace isobus
 		/// working set master
 		enum class TractorImplementManagementOptions
 		{
-			NoOptions,
+			NoOptions = 0,
 			FrontPTODisengagementIsSupported,
 			FrontPTOEngagementCCWIsSupported,
 			FrontPTOengagementCWIsSupported,
@@ -158,6 +161,9 @@ namespace isobus
 		/// @param[in] sourceControlFunction The control function to use when sending messages
 		explicit ControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction);
 
+		/// @brief Destructor for a ControlFunctionFunctionalities object
+		~ControlFunctionFunctionalities();
+
 		/// @brief Adds or removes a supported functionality
 		/// @param[in] functionality The functionality to change
 		/// @param[in] functionalityGeneration The generation of the functionality to report
@@ -183,12 +189,22 @@ namespace isobus
 		/// @param[in] optionState The state to set for the associated option
 		void set_minimum_control_function_option_state(MinimumControlFunctionOptions option, bool optionState);
 
+		/// @brief Returns the current state of the specified minimum control function functionality option
+		/// @param[in] option The option to check the state of
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_minimum_control_function_option_state(MinimumControlFunctionOptions option);
+
 		/// @brief Sets an AUX-O inputs functionality option to a new state.
 		/// @details Options set to true will be reported as "supported" to a requester of your
 		/// control function functionalities within the "AUX-O inputs" functionality section of the message.
 		/// @param[in] option The option to set
 		/// @param[in] optionState The state to set for the associated option
 		void set_aux_O_inputs_option_state(AuxOOptions option, bool optionState);
+
+		/// @brief Gets the state of an AUX-O inputs functionality option.
+		/// @param[in] option The option to get
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_aux_O_inputs_option_state(AuxOOptions option);
 
 		/// @brief Sets an AUX-O functions functionality option to a new state.
 		/// @details Options set to true will be reported as "supported" to a requester of your
@@ -197,12 +213,22 @@ namespace isobus
 		/// @param[in] optionState The state to set for the associated option
 		void set_aux_O_functions_option_state(AuxOOptions option, bool optionState);
 
+		/// @brief Gets the state of an AUX-O functions functionality option.
+		/// @param[in] option The option to get
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_aux_O_functions_option_state(AuxOOptions option);
+
 		/// @brief Sets an AUX-N inputs functionality option to a new state.
 		/// @details Options set to true will be reported as "supported" to a requester of your
 		/// control function functionalities within the "AUX-N inputs" functionality section of the message.
 		/// @param[in] option The option to set
 		/// @param[in] optionState The state to set for the associated option
 		void set_aux_N_inputs_option_state(AuxNOptions option, bool optionState);
+
+		/// @brief Gets the state of an AUX-N inputs functionality option.
+		/// @param[in] option The option to get
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_aux_N_inputs_option_state(AuxNOptions option);
 
 		/// @brief Sets an AUX-N functions functionality option to a new state.
 		/// @details Options set to true will be reported as "supported" to a requester of your
@@ -211,6 +237,11 @@ namespace isobus
 		/// @param[in] optionState The state to set for the associated option
 		void set_aux_N_functions_option_state(AuxNOptions option, bool optionState);
 
+		/// @brief Gets the state of an AUX-N functions functionality option.
+		/// @param[in] option The option to get
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_aux_N_functions_option_state(AuxNOptions option);
+
 		/// @brief Sets a task controller geo server functionality option to a new state.
 		/// @details Options set to true will be reported as "supported" to a requester of your
 		/// control function functionalities within the "task controller geo server" functionality section of the message.
@@ -218,11 +249,20 @@ namespace isobus
 		/// @param[in] optionState The state to set for the associated option
 		void set_task_controller_geo_server_option_state(TaskControllerGeoServerOptions option, bool optionState);
 
+		/// @brief Gets the state of a TC GEO server functionality option.
+		/// @param[in] option The option to get
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_task_controller_geo_server_option_state(TaskControllerGeoServerOptions option);
+
 		/// @brief Sets a task controller geo client's only functionality option, which is the number of control channels.
 		/// @details The value you set will be reported to the requestor of your CF's functionalities
 		/// within the "task controller geo client" functionality section of the message.
 		/// @param[in] numberOfControlChannels The number of control channels your ECU supports for TC GEO (client side)
 		void set_task_controller_geo_client_option(std::uint8_t numberOfControlChannels);
+
+		/// @brief Gets the state of the only TC GEO client functionality option, which is the number of control channels.
+		/// @returns The number of supported TC GEO client control channels that are supported
+		std::uint8_t get_task_controller_geo_client_option();
 
 		/// @brief Sets a task controller section control server's options
 		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
@@ -230,11 +270,27 @@ namespace isobus
 		/// @param[in] numberOfSupportedSections The number of sections your application TC server supports
 		void set_task_controller_section_control_server_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections);
 
+		/// @brief Gets the number of supported booms for the TC section control server functionality
+		/// @returns The number of supported booms being reported in the TC section control server functionality
+		std::uint8_t get_task_controller_section_control_server_number_supported_booms();
+
+		/// @brief Gets the number of supported sections for the TC section control server functionality
+		/// @returns The number of supported sections being reported in the TC section control server functionality
+		std::uint8_t get_task_controller_section_control_server_number_supported_sections();
+
 		/// @brief Sets a task controller section control client's options
 		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
 		/// @param[in] numberOfSupportedBooms The number of booms your application TC client supports
 		/// @param[in] numberOfSupportedSections The number of sections your application TC client supports
 		void set_task_controller_section_control_client_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections);
+
+		/// @brief Gets the number of supported booms for the TC section control client functionality
+		/// @returns The number of supported booms being reported in the TC section control client functionality
+		std::uint8_t get_task_controller_section_control_client_number_supported_booms();
+
+		/// @brief Gets the number of supported sections for the TC section control client functionality
+		/// @returns The number of supported sections being reported in the TC section control client functionality
+		std::uint8_t get_task_controller_section_control_client_number_supported_sections();
 
 		/// @brief Sets a tractor ECU server functionality option to a new state.
 		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
@@ -242,17 +298,32 @@ namespace isobus
 		/// @param[in] optionState The state to set for the associated option
 		void set_basic_tractor_ECU_server_option_state(BasicTractorECUOptions option, bool optionState);
 
+		/// @brief Gets the state of a basic tractor ECU server functionality option.
+		/// @param[in] option The option to get
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_basic_tractor_ECU_server_option_state(BasicTractorECUOptions option);
+
 		/// @brief Sets a tractor ECU client functionality option to a new state.
 		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
 		/// @param[in] option The option to set
 		/// @param[in] optionState The state to set for the associated option
 		void set_basic_tractor_ECU_implement_client_option_state(BasicTractorECUOptions option, bool optionState);
 
+		/// @brief Gets the state of a basic tractor ECU implement client functionality option.
+		/// @param[in] option The option to get
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_basic_tractor_ECU_implement_client_option_state(BasicTractorECUOptions option);
+
 		/// @brief Sets a tractor implement management (TIM) server functionality option to a new state.
 		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
 		/// @param[in] option The option to set
 		/// @param[in] optionState The state to set for the associated option
 		void set_tractor_implement_management_server_option_state(TractorImplementManagementOptions option, bool optionState);
+
+		/// @brief Gets the state of a basic tractor implement management client functionality option.
+		/// @param[in] option The option to get
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_tractor_implement_management_server_option_state(TractorImplementManagementOptions option);
 
 		/// @brief Sets a tractor implement management (TIM) server aux valve's functionality options to a new state
 		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
@@ -261,11 +332,26 @@ namespace isobus
 		/// @param[in] flowSupported Set to true to indicate your support aux valve flow with this valve
 		void set_tractor_implement_management_server_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported);
 
+		/// @brief Returns if a particular aux valve's state control is supported in the TIM server functionality
+		/// @param[in] auxValveIndex The index of the aux valve to check
+		/// @returns true if the aux valve's state you specified is being reported as "supported".
+		bool get_tractor_implement_management_server_aux_valve_state_supported(std::uint8_t auxValveIndex);
+
+		/// @brief Returns if a particular aux valve's flow control is supported in the TIM server functionality
+		/// @param[in] auxValveIndex The index of the aux valve to check
+		/// @returns true if the aux valve you specified is being reported as "supported".
+		bool get_tractor_implement_management_server_aux_valve_flow_supported(std::uint8_t auxValveIndex);
+
 		/// @brief Sets a tractor implement management (TIM) client functionality option to a new state.
 		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
 		/// @param[in] option The option to set
 		/// @param[in] optionState The state to set for the associated option
 		void set_tractor_implement_management_client_option_state(TractorImplementManagementOptions option, bool optionState);
+
+		/// @brief Gets the state of a TIM client functionality option.
+		/// @param[in] option The option to get
+		/// @returns The state of the option. If true, the option is being reported as "supported".
+		bool get_tractor_implement_management_client_option_state(TractorImplementManagementOptions option);
 
 		/// @brief Sets a tractor implement management (TIM) client aux valve's functionality options to a new state
 		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
@@ -273,6 +359,35 @@ namespace isobus
 		/// @param[in] stateSupported Set to true to indicate you support the state of this valve, otherwise false
 		/// @param[in] flowSupported Set to true to indicate your support aux valve flow with this valve
 		void set_tractor_implement_management_client_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported);
+
+		/// @brief Returns if a particular aux valve's state control is supported in the TIM client functionality
+		/// @param[in] auxValveIndex The index of the aux valve to check
+		/// @returns true if the aux valve's state you specified is being reported as "supported".
+		bool get_tractor_implement_management_client_aux_valve_state_supported(std::uint8_t auxValveIndex);
+
+		/// @brief Returns if a particular aux valve's flow control is supported in the TIM client functionality
+		/// @param[in] auxValveIndex The index of the aux valve to check
+		/// @returns true if the aux valve you specified is being reported as "supported".
+		bool get_tractor_implement_management_client_aux_valve_flow_supported(std::uint8_t auxValveIndex);
+
+		/// @brief The network manager calls this to see if the protocol can accept a non-raw CAN message for processing
+		/// @returns true if the message was accepted by the protocol for processing
+		bool protocol_transmit_message(std::uint32_t,
+		                               const std::uint8_t *,
+		                               std::uint32_t,
+		                               ControlFunction *,
+		                               ControlFunction *,
+		                               TransmitCompleteCallback,
+		                               void *,
+		                               DataChunkCallback) override;
+
+		/// @brief This will be called by the network manager on every cyclic update of the stack
+		void update(CANLibBadge<CANNetworkManager>) override;
+
+	protected:
+		/// @brief Populates a vector with the message data needed to send PGN 0xFC8E
+		/// @param[in,out] messageData The buffer to populate with data (will be cleared before use)
+		void get_message_content(std::vector<std::uint8_t> &messageData);
 
 	private:
 		/// @brief Stores the raw byte data associated with a functionality based on
@@ -295,9 +410,24 @@ namespace isobus
 			/// @param[in] value The new value for the desired bit
 			void set_bit_in_option(std::uint8_t byteIndex, std::uint8_t bit, bool value);
 
+			/// @brief A helper function to get a particular bit's value in the specified option byte
+			/// @note If the parameters are out of range, this will return zero.
+			/// @param[in] byteIndex The options byte index inside which the bit should be retrieved
+			/// @param[in] bit The bit offset index of the bit you want to get, between 0 and 7
+			/// @returns The state of the requested bit
+			bool get_bit_in_option(std::uint8_t byteIndex, std::uint8_t bit);
+
 			Functionalities functionality = Functionalities::MinimumControlFunction; ///< The funcionalty associated with this data
 			std::vector<std::uint8_t> serializedValue; ///< The raw message data value for this functionality
 			std::uint8_t generation = 1; ///< The generation of the functionality supported
+		};
+
+		/// @brief Enumerates a set of flags representing messages to be transmitted by this interfaces
+		enum class TransmitFlags : std::uint32_t
+		{
+			ControlFunctionFunctionalitiesMessage = 0, ///< A flag to send the CF Functionalities message
+
+			NumberOfFlags ///< The number of flags enumerated in this enum
 		};
 
 		/// @brief Checks for the existance of a functionality in the list of previously configured functionalities
@@ -306,9 +436,12 @@ namespace isobus
 		/// @returns Iterator to the desired functionality, or supportedFunctionalities.end() if not found
 		std::list<FunctionalityData>::iterator get_functionality(Functionalities functionalityToRetreive);
 
-		/// @brief Populates a vector with the message data needed to send PGN 0xFC8E
-		/// @param[in,out] messageData The buffer to populate with data (will be cleared before use)
-		void get_message_content(std::vector<std::uint8_t> &messageData);
+		/// @brief A wrapper to to get an option from the first byte of a functionalities' data
+		/// @param[in] functionality The functionality associated to the option being retrieved
+		/// @param[in] byteIndex The index of the option byte to query within
+		/// @param[in] option The option bit to get the state for
+		/// @returns The state of the bit that was requested
+		bool get_functionality_byte_option(Functionalities functionality, std::uint8_t byteIndex, std::uint8_t option);
 
 		/// @brief Returns the byte index of the specified TIM option in the CF Functionalities message data
 		/// associated with wither TIM server or TIM client functionalities.
@@ -322,11 +455,34 @@ namespace isobus
 		/// @returns The bit offset/index of the specified option int the TIM functionality message data
 		std::uint8_t get_tim_option_bit_index(TractorImplementManagementOptions option) const;
 
+		/// @brief A generic way for a protocol to process a received message
+		/// @param[in] message A received CAN message
+		void process_message(CANMessage *const message) override;
+
+		/// @brief Handles PGN requests for the control function functionalities message
+		/// @param[in] parameterGroupNumber The PGN that was requested
+		/// @param[in] requestingControlFunction The control function that is requesting the PGN
+		/// @param[out] acknowledge Tells the PGN request protocol to ACK ack the request
+		/// @param[out] acknowledgeType Tells the PGN request protocol what kind of ACK to use
+		/// @param[in] parentPointer A generic context variable, usually the "this" pointer of the registrant for callbacks
+		static bool pgn_request_handler(std::uint32_t parameterGroupNumber,
+		                                ControlFunction *requestingControlFunction,
+		                                bool &acknowledge,
+		                                AcknowledgementType &acknowledgeType,
+		                                void *parentPointer);
+
+		/// @brief Processes set transmit flags to send messages
+		/// @param[in] flag The flag to process
+		/// @param[in] parentPointer A pointer back to an instance of this interface
+		static void process_flags(std::uint32_t flag, void *parentPointer);
+
 		static constexpr std::uint8_t NUMBER_TIM_AUX_VALVES_PER_BYTE = 4; ///< The number of aux valves per byte of TIM functionality message data
+		static constexpr std::uint8_t NUMBER_TIM_AUX_VALVES = 32; ///< The max number of TIM aux valves
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The control function to send messages as
 		std::list<FunctionalityData> supportedFunctionalities; ///< A list of all configured functionalities and their data
 		std::mutex functionalitiesMutex; ///< Since messages come in on a different thread than the main app (probably), this mutex protects the functionality data
+		ProcessingFlags txFlags; ///< Handles retries for sending the CF functionalities message
 	};
 } // namespace isobus
 #endif // ISOBUS_FUNCTIONALITIES_HPP

--- a/isobus/include/isobus/isobus/isobus_functionalities.hpp
+++ b/isobus/include/isobus/isobus/isobus_functionalities.hpp
@@ -78,7 +78,7 @@ namespace isobus
 		};
 
 		/// @brief This parameter reports which auxiliary control type 2 functionality type functions are supported by
-		// an implement working set auxiliary function or an auxiliary function input unit.
+		/// an implement working set auxiliary function or an auxiliary function input unit.
 		enum class AuxNOptions : std::uint16_t
 		{
 			NoOptions = 0x00,
@@ -165,25 +165,113 @@ namespace isobus
 		/// @note Minimum Control Function is enabled by defualt, and generally should not be disabled.
 		void set_functionality_is_supported(Functionalities functionality, std::uint8_t functionalityGeneration, bool isSupported);
 
+		/// @brief Returns if a functionality was previously configured with set_functionality_is_supported
+		/// @param[in] functionality The functionality to check against
+		/// @returns true if the specified functionality will be reported as being supported, otherwise false
 		bool get_functionality_is_supported(Functionalities functionality);
 
+		/// @brief Returns the generation that was set for the specified functionality when
+		/// set_functionality_is_supported was called for that functionality.
+		/// @param[in] functionality The functionality to check against
+		/// @returns The generation associated with the specified functionality, or 0 if not configured
 		std::uint8_t get_functionality_generation(Functionalities functionality);
 
+		/// @brief Sets a minimum control function functionality option to a new state.
+		/// @details Options set to true will be reported as "supported" to a requester of your
+		/// control function functionalities within the "minimum control function" functionality section of the message.
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_minimum_control_function_option_state(MinimumControlFunctionOptions option, bool optionState);
 
+		/// @brief Sets an AUX-O inputs functionality option to a new state.
+		/// @details Options set to true will be reported as "supported" to a requester of your
+		/// control function functionalities within the "AUX-O inputs" functionality section of the message.
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_aux_O_inputs_option_state(AuxOOptions option, bool optionState);
+
+		/// @brief Sets an AUX-O functions functionality option to a new state.
+		/// @details Options set to true will be reported as "supported" to a requester of your
+		/// control function functionalities within the "AUX-O functions" functionality section of the message.
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_aux_O_functions_option_state(AuxOOptions option, bool optionState);
+
+		/// @brief Sets an AUX-N inputs functionality option to a new state.
+		/// @details Options set to true will be reported as "supported" to a requester of your
+		/// control function functionalities within the "AUX-N inputs" functionality section of the message.
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_aux_N_inputs_option_state(AuxNOptions option, bool optionState);
+
+		/// @brief Sets an AUX-N functions functionality option to a new state.
+		/// @details Options set to true will be reported as "supported" to a requester of your
+		/// control function functionalities within the "AUX-N functions" functionality section of the message.
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_aux_N_functions_option_state(AuxNOptions option, bool optionState);
+
+		/// @brief Sets a task controller geo server functionality option to a new state.
+		/// @details Options set to true will be reported as "supported" to a requester of your
+		/// control function functionalities within the "task controller geo server" functionality section of the message.
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_task_controller_geo_server_option_state(TaskControllerGeoServerOptions option, bool optionState);
+
+		/// @brief Sets a task controller geo client's only functionality option, which is the number of control channels.
+		/// @details The value you set will be reported to the requestor of your CF's functionalities
+		/// within the "task controller geo client" functionality section of the message.
+		/// @param[in] numberOfControlChannels The number of control channels your ECU supports for TC GEO (client side)
 		void set_task_controller_geo_client_option(std::uint8_t numberOfControlChannels);
-		void set_task_controller_section_control_server_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections, bool optionState);
-		void set_task_controller_section_control_client_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections, bool optionState);
+
+		/// @brief Sets a task controller section control server's options
+		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
+		/// @param[in] numberOfSupportedBooms The number of booms your application TC server supports
+		/// @param[in] numberOfSupportedSections The number of sections your application TC server supports
+		void set_task_controller_section_control_server_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections);
+
+		/// @brief Sets a task controller section control client's options
+		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
+		/// @param[in] numberOfSupportedBooms The number of booms your application TC client supports
+		/// @param[in] numberOfSupportedSections The number of sections your application TC client supports
+		void set_task_controller_section_control_client_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections);
+
+		/// @brief Sets a tractor ECU server functionality option to a new state.
+		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_basic_tractor_ECU_server_option_state(BasicTractorECUOptions option, bool optionState);
+
+		/// @brief Sets a tractor ECU client functionality option to a new state.
+		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_basic_tractor_ECU_implement_client_option_state(BasicTractorECUOptions option, bool optionState);
+
+		/// @brief Sets a tractor implement management (TIM) server functionality option to a new state.
+		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_tractor_implement_management_server_option_state(TractorImplementManagementOptions option, bool optionState);
+
+		/// @brief Sets a tractor implement management (TIM) server aux valve's functionality options to a new state
+		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
+		/// @param[in] auxValveIndex The index of the aux valve to set, between 0 and 31
+		/// @param[in] stateSupported Set to true to indicate you support the state of this valve, otherwise false
+		/// @param[in] flowSupported Set to true to indicate your support aux valve flow with this valve
 		void set_tractor_implement_management_server_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported);
+
+		/// @brief Sets a tractor implement management (TIM) client functionality option to a new state.
+		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
+		/// @param[in] option The option to set
+		/// @param[in] optionState The state to set for the associated option
 		void set_tractor_implement_management_client_option_state(TractorImplementManagementOptions option, bool optionState);
+
+		/// @brief Sets a tractor implement management (TIM) client aux valve's functionality options to a new state
+		/// @details The values set here will be reported as "supported" to a requester of your CF's functionalities
+		/// @param[in] auxValveIndex The index of the aux valve to set, between 0 and 31
+		/// @param[in] stateSupported Set to true to indicate you support the state of this valve, otherwise false
+		/// @param[in] flowSupported Set to true to indicate your support aux valve flow with this valve
 		void set_tractor_implement_management_client_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported);
 
 	private:
@@ -222,11 +310,19 @@ namespace isobus
 		/// @param[in,out] messageData The buffer to populate with data (will be cleared before use)
 		void get_message_content(std::vector<std::uint8_t> &messageData);
 
+		/// @brief Returns the byte index of the specified TIM option in the CF Functionalities message data
+		/// associated with wither TIM server or TIM client functionalities.
+		/// @param[in] option The option for which you want to know the byte index
+		/// @returns The byte index of the specified option in the TIM functionalities' message data
 		std::uint8_t get_tim_option_byte_index(TractorImplementManagementOptions option) const;
 
+		/// @brief Returns the bit offset of a specified TIM functionality option into the
+		/// TIM client and server functionality message data
+		/// @param[in] option The option for which you want to know the bit index into the TIM functionality message data
+		/// @returns The bit offset/index of the specified option int the TIM functionality message data
 		std::uint8_t get_tim_option_bit_index(TractorImplementManagementOptions option) const;
 
-		static constexpr std::uint8_t NUMBER_TIM_AUX_VALVES_PER_BYTE = 4;
+		static constexpr std::uint8_t NUMBER_TIM_AUX_VALVES_PER_BYTE = 4; ///< The number of aux valves per byte of TIM functionality message data
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The control function to send messages as
 		std::list<FunctionalityData> supportedFunctionalities; ///< A list of all configured functionalities and their data

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -68,6 +68,7 @@ namespace isobus
 	}
 
 	DiagnosticProtocol::DiagnosticProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction) :
+	  ControlFunctionFunctionalitiesMessageInterface(internalControlFunction),
 	  myControlFunction(internalControlFunction),
 	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberOfFlags), process_flags, this),
 	  lastDM1SentTimestamp(0),
@@ -475,6 +476,7 @@ namespace isobus
 			}
 		}
 		txFlags.process_all_flags();
+		ControlFunctionFunctionalitiesMessageInterface.update();
 	}
 
 	std::uint8_t DiagnosticProtocol::convert_flash_state_to_byte(FlashState flash)

--- a/isobus/src/isobus_functionalities.cpp
+++ b/isobus/src/isobus_functionalities.cpp
@@ -1,0 +1,463 @@
+//================================================================================================
+/// @file isobus_functionalities.cpp
+///
+/// @brief Implements the management of the ISOBUS control function functionalities message.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
+#include "isobus/isobus/isobus_functionalities.hpp"
+#include "isobus/isobus/can_stack_logger.hpp"
+
+#include <limits>
+
+namespace isobus
+{
+	void ControlFunctionFunctionalities::set_functionality_is_supported(Functionalities functionality, std::uint8_t functionalityGeneration, bool isSupported)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(functionality);
+
+		if (supportedFunctionalities.end() == existingFunctionality)
+		{
+			FunctionalityData newFunctionality(functionality);
+			newFunctionality.configure_default_data();
+			newFunctionality.generation = functionalityGeneration;
+			supportedFunctionalities.emplace_back(newFunctionality);
+		}
+	}
+
+	bool ControlFunctionFunctionalities::get_functionality_is_supported(Functionalities functionality)
+	{
+		bool retVal = false;
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(functionality);
+
+		if (supportedFunctionalities.end() != existingFunctionality)
+		{
+			retVal = true;
+		}
+		return retVal;
+	}
+
+	std::uint8_t ControlFunctionFunctionalities::get_functionality_generation(Functionalities functionality)
+	{
+		std::uint8_t retVal = 0;
+
+		auto existingFunctionality = get_functionality(functionality);
+
+		if (supportedFunctionalities.end() != existingFunctionality)
+		{
+			retVal = existingFunctionality->generation;
+		}
+		return retVal;
+	}
+
+	void ControlFunctionFunctionalities::set_aux_O_inputs_option_state(AuxOOptions option, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::AuxOInputs);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (option < AuxOOptions::Reserved))
+		{
+			existingFunctionality->set_bit_in_option(0, static_cast<std::uint8_t>(option), optionState);
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_aux_O_functions_option_state(AuxOOptions option, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::AuxOFunctions);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (option < AuxOOptions::Reserved))
+		{
+			existingFunctionality->set_bit_in_option(0, static_cast<std::uint8_t>(option), optionState);
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_aux_N_inputs_option_state(AuxNOptions option, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::AuxNInputs);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (option < AuxNOptions::Reserved))
+		{
+			existingFunctionality->set_bit_in_option(option > AuxNOptions::SupportsType7Function ? 1 : 0,
+			                                         option > AuxNOptions::SupportsType7Function ? static_cast<std::uint8_t>(static_cast<std::uint16_t>(option) >> 8) : static_cast<std::uint8_t>(option),
+			                                         optionState);
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_aux_N_functions_option_state(AuxNOptions option, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::AuxNFunctions);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (option < AuxNOptions::Reserved))
+		{
+			existingFunctionality->set_bit_in_option(option > AuxNOptions::SupportsType7Function ? 1 : 0,
+			                                         option > AuxNOptions::SupportsType7Function ? static_cast<std::uint8_t>(static_cast<std::uint16_t>(option) >> 8) : static_cast<std::uint8_t>(option),
+			                                         optionState);
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_task_controller_geo_server_option_state(TaskControllerGeoServerOptions option, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::TaskControllerGeoServer);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (option < TaskControllerGeoServerOptions::Reserved))
+		{
+			existingFunctionality->set_bit_in_option(0, static_cast<std::uint8_t>(option), optionState);
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_task_controller_geo_client_option(std::uint8_t numberOfControlChannels)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::TaskControllerGeoClient);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (numberOfControlChannels > 0))
+		{
+			existingFunctionality->serializedValue.at(0) = numberOfControlChannels;
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_task_controller_section_control_server_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::TaskControllerSectionControlServer);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (numberOfSupportedBooms > 0) &&
+		    (numberOfSupportedSections > 0))
+		{
+			existingFunctionality->serializedValue.at(0) = numberOfSupportedBooms;
+			existingFunctionality->serializedValue.at(1) = numberOfSupportedSections;
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_task_controller_section_control_client_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::TaskControllerSectionControlClient);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (numberOfSupportedBooms > 0) &&
+		    (numberOfSupportedSections > 0))
+		{
+			existingFunctionality->serializedValue.at(0) = numberOfSupportedBooms;
+			existingFunctionality->serializedValue.at(1) = numberOfSupportedSections;
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_basic_tractor_ECU_server_option_state(BasicTractorECUOptions option, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::BasicTractorECUServer);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (option < BasicTractorECUOptions::Reserved))
+		{
+			existingFunctionality->set_bit_in_option(0, static_cast<std::uint8_t>(option), optionState);
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_basic_tractor_ECU_implement_client_option_state(BasicTractorECUOptions option, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::BasicTractorECUImplementClient);
+
+		if ((supportedFunctionalities.end() != existingFunctionality) &&
+		    (option < BasicTractorECUOptions::Reserved))
+		{
+			existingFunctionality->set_bit_in_option(0, static_cast<std::uint8_t>(option), optionState);
+		}
+	}
+	void ControlFunctionFunctionalities::set_tractor_implement_management_server_option_state(TractorImplementManagementOptions option, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementServer);
+
+		if (supportedFunctionalities.end() != existingFunctionality)
+		{
+			existingFunctionality->set_bit_in_option(get_tim_option_byte_index(option), get_tim_option_bit_index(option), optionState);
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_tractor_implement_management_server_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementServer);
+
+		if (supportedFunctionalities.end() != existingFunctionality)
+		{
+			existingFunctionality->set_bit_in_option(auxValveIndex / 4, 2 * (auxValveIndex % 4), stateSupported);
+			existingFunctionality->set_bit_in_option(auxValveIndex / 4, 2 * (auxValveIndex % 4) + 1, flowSupported);
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_tractor_implement_management_client_option_state(TractorImplementManagementOptions option, bool optionState)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+
+		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementClient);
+
+		if (supportedFunctionalities.end() != existingFunctionality)
+		{
+			existingFunctionality->set_bit_in_option(get_tim_option_byte_index(option), get_tim_option_bit_index(option), optionState);
+		}
+	}
+
+	void ControlFunctionFunctionalities::set_tractor_implement_management_client_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported)
+	{
+		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
+	}
+
+	ControlFunctionFunctionalities::FunctionalityData::FunctionalityData(Functionalities functionalityToStore) :
+	  functionality(functionalityToStore)
+	{
+	}
+
+	void ControlFunctionFunctionalities::FunctionalityData::configure_default_data()
+	{
+		switch (functionality)
+		{
+			case Functionalities::MinimumControlFunction:
+			case Functionalities::UniversalTerminalServer:
+			case Functionalities::UniversalTerminalWorkingSet:
+			case Functionalities::AuxOInputs:
+			case Functionalities::AuxOFunctions:
+			case Functionalities::TaskControllerBasicServer:
+			case Functionalities::TaskControllerBasicClient:
+			case Functionalities::TaskControllerGeoServer:
+			case Functionalities::TaskControllerGeoClient:
+			case Functionalities::BasicTractorECUServer:
+			case Functionalities::BasicTractorECUImplementClient:
+			case Functionalities::FileServer:
+			case Functionalities::FileServerClient:
+			{
+				serializedValue.resize(1);
+				serializedValue.at(0) = 0x00; // No options
+			}
+			break;
+
+			case Functionalities::AuxNInputs:
+			case Functionalities::AuxNFunctions:
+			{
+				serializedValue.resize(2);
+				serializedValue.at(0) = 0x00; // No options
+				serializedValue.at(1) = 0x00; // No options
+			}
+			break;
+
+			case Functionalities::TaskControllerSectionControlServer:
+			case Functionalities::TaskControllerSectionControlClient:
+			{
+				serializedValue.resize(2);
+				serializedValue.at(0) = 0x01; // 1 Boom supported (1 is the minimum)
+				serializedValue.at(1) = 0x01; // 1 Section Supported (1 is the minimum)
+			}
+			break;
+
+			case Functionalities::TractorImplementManagementServer:
+			case Functionalities::TractorImplementManagementClient:
+			{
+				CANStackLogger::warn("[DP]: You have configured TIM as a CF functionality, but the library doesn't support TIM at this time. Do you have an external TIM implementation?");
+				serializedValue.resize(15); // TIM has a lot of options. https://www.isobus.net/isobus/option
+				std::fill(serializedValue.begin(), serializedValue.end(), 0x00); // Support nothing by default
+			}
+			break;
+
+			default:
+			{
+				CANStackLogger::error("[DP]: An invalid control function functionality was added. It's values will be ignored.");
+			}
+			break;
+		}
+	}
+
+	void ControlFunctionFunctionalities::FunctionalityData::set_bit_in_option(std::uint8_t byteIndex, std::uint8_t bit, bool value)
+	{
+		if ((byteIndex < serializedValue.size()) && (bit < std::numeric_limits<std::uint8_t>::digits))
+		{
+			if (value)
+			{
+				serializedValue.at(byteIndex) = (serializedValue.at(byteIndex) | (1 << bit));
+			}
+			else
+			{
+				serializedValue.at(byteIndex) = (serializedValue.at(byteIndex) & ~(1 << bit));
+			}
+		}
+	}
+
+	std::list<ControlFunctionFunctionalities::FunctionalityData>::iterator ControlFunctionFunctionalities::get_functionality(Functionalities functionalityToRetreive)
+	{
+		return std::find_if(supportedFunctionalities.begin(), supportedFunctionalities.end(), [functionalityToRetreive](FunctionalityData &currentFunctionality) { return currentFunctionality.functionality == functionalityToRetreive; });
+	}
+
+	void ControlFunctionFunctionalities::get_message_content(std::vector<std::uint8_t> &messageData)
+	{
+		messageData.clear();
+		messageData.push_back(0xFF); // Each control function shall respond with byte 1 set to FF
+		messageData.push_back(static_cast<std::uint8_t>(supportedFunctionalities.size()));
+	}
+
+	std::uint8_t ControlFunctionFunctionalities::get_tim_option_byte_index(TractorImplementManagementOptions option) const
+	{
+		std::uint8_t retVal = 0xFF;
+
+		switch (option)
+		{
+			case TractorImplementManagementOptions::FrontPTODisengagementIsSupported:
+			case TractorImplementManagementOptions::FrontPTOEngagementCCWIsSupported:
+			case TractorImplementManagementOptions::FrontPTOengagementCWIsSupported:
+			case TractorImplementManagementOptions::FrontPTOspeedCCWIsSupported:
+			case TractorImplementManagementOptions::FrontPTOspeedCWIsSupported:
+			{
+				retVal = 9;
+			}
+			break;
+
+			case TractorImplementManagementOptions::RearPTODisengagementIsSupported:
+			case TractorImplementManagementOptions::RearPTOEngagementCCWIsSupported:
+			case TractorImplementManagementOptions::RearPTOEngagementCWIsSupported:
+			case TractorImplementManagementOptions::RearPTOSpeedCCWIsSupported:
+			case TractorImplementManagementOptions::RearPTOSpeedCWIsSupported:
+			{
+				retVal = 10;
+			}
+			break;
+
+			case TractorImplementManagementOptions::FrontHitchMotionIsSupported:
+			case TractorImplementManagementOptions::FrontHitchPositionIsSupported:
+			{
+				retVal = 11;
+			}
+			break;
+
+			case TractorImplementManagementOptions::RearHitchMotionIsSupported:
+			case TractorImplementManagementOptions::RearHitchPositionIsSupported:
+			{
+				retVal = 12;
+			}
+			break;
+
+			case TractorImplementManagementOptions::VehicleSpeedInForwardDirectionIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedInReverseDirectionIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedStartMotionIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedStopMotionIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedForwardSetByServerIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedReverseSetByServerIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedChangeDirectionIsSupported:
+			{
+				retVal = 13;
+			}
+			break;
+
+			case TractorImplementManagementOptions::GuidanceCurvatureIsSupported:
+			{
+				retVal = 14;
+			}
+			break;
+
+			default:
+			{
+			}
+			break;
+		}
+		return retVal;
+	}
+
+	std::uint8_t ControlFunctionFunctionalities::get_tim_option_bit_index(TractorImplementManagementOptions option) const
+	{
+		std::uint8_t retVal = 0xFF;
+
+		switch (option)
+		{
+			case TractorImplementManagementOptions::FrontPTODisengagementIsSupported:
+			case TractorImplementManagementOptions::RearPTODisengagementIsSupported:
+			case TractorImplementManagementOptions::FrontHitchMotionIsSupported:
+			case TractorImplementManagementOptions::RearHitchMotionIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedInForwardDirectionIsSupported:
+			case TractorImplementManagementOptions::GuidanceCurvatureIsSupported:
+			{
+				retVal = 0;
+			}
+			break;
+
+			case TractorImplementManagementOptions::FrontPTOEngagementCCWIsSupported:
+			case TractorImplementManagementOptions::RearPTOEngagementCCWIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedInReverseDirectionIsSupported:
+			{
+				retVal = 1;
+			}
+			break;
+
+			case TractorImplementManagementOptions::FrontHitchPositionIsSupported:
+			case TractorImplementManagementOptions::RearHitchPositionIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedStartMotionIsSupported:
+			{
+				retVal = 2;
+			}
+			break;
+
+			case TractorImplementManagementOptions::FrontPTOengagementCWIsSupported:
+			case TractorImplementManagementOptions::RearPTOEngagementCWIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedStopMotionIsSupported:
+			{
+				retVal = 3;
+			}
+			break;
+
+			case TractorImplementManagementOptions::FrontPTOspeedCCWIsSupported:
+			case TractorImplementManagementOptions::RearPTOSpeedCCWIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedForwardSetByServerIsSupported:
+			{
+				retVal = 4;
+			}
+			break;
+
+			case TractorImplementManagementOptions::FrontPTOspeedCWIsSupported:
+			case TractorImplementManagementOptions::RearPTOSpeedCWIsSupported:
+			case TractorImplementManagementOptions::VehicleSpeedReverseSetByServerIsSupported:
+			{
+				retVal = 5;
+			}
+			break;
+
+			case TractorImplementManagementOptions::VehicleSpeedChangeDirectionIsSupported:
+			{
+				retVal = 6;
+			}
+			break;
+
+			default:
+			{
+			}
+			break;
+		}
+		return retVal;
+	}
+} // namespace isobus

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -8,7 +8,21 @@
 
 using namespace isobus;
 
-TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, asdf)
+class TestControlFunctionFunctionalities : public ControlFunctionFunctionalities
+{
+public:
+	explicit TestControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction) :
+	  ControlFunctionFunctionalities(sourceControlFunction)
+	{
+	}
+
+	void test_wrapper_get_message_content(std::vector<std::uint8_t> &messageData)
+	{
+		ControlFunctionFunctionalities::get_message_content(messageData);
+	}
+};
+
+TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 {
 	VirtualCANPlugin requesterPlugin;
 	requesterPlugin.open();
@@ -50,7 +64,466 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, asdf)
 	testFrame.data[7] = 0xA0;
 	CANNetworkManager::process_receive_can_message_frame(testFrame);
 
+	TestControlFunctionFunctionalities cfFunctionalitiesUnderTest(internalECU);
+
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::MinimumControlFunction));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::UniversalTerminalServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::UniversalTerminalWorkingSet));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxOInputs));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxOFunctions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNInputs));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNFunctions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerBasicServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerBasicClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerGeoServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerGeoClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUImplementClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::FileServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::FileServerClient));
+
+	// Pretend we have weak internal termination
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination, true);
+
+	// None of these options should do anything when the functionality hasn't been enabled
+	cfFunctionalitiesUnderTest.set_aux_N_functions_option_state(ControlFunctionFunctionalities::AuxNOptions::SupportsType8Function, true);
+	cfFunctionalitiesUnderTest.set_aux_N_inputs_option_state(ControlFunctionFunctionalities::AuxNOptions::SupportsType9Function, true);
+	cfFunctionalitiesUnderTest.set_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function, true);
+	cfFunctionalitiesUnderTest.set_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function, true);
+	cfFunctionalitiesUnderTest.set_basic_tractor_ECU_implement_client_option_state(ControlFunctionFunctionalities::BasicTractorECUOptions::Class2NoOptions, true);
+	cfFunctionalitiesUnderTest.set_basic_tractor_ECU_server_option_state(ControlFunctionFunctionalities::BasicTractorECUOptions::Class1NoOptions, true);
+	cfFunctionalitiesUnderTest.set_task_controller_geo_client_option(123);
+	cfFunctionalitiesUnderTest.set_task_controller_geo_server_option_state(ControlFunctionFunctionalities::TaskControllerGeoServerOptions::PolygonBasedPrescriptionMapsAreSupported, true);
+	cfFunctionalitiesUnderTest.set_tractor_implement_management_client_aux_valve_option(4, true, true);
+	cfFunctionalitiesUnderTest.set_tractor_implement_management_client_option_state(ControlFunctionFunctionalities::TractorImplementManagementOptions::FrontPTOengagementCWIsSupported, true);
+	cfFunctionalitiesUnderTest.set_tractor_implement_management_server_aux_valve_option(6, true, true);
+	cfFunctionalitiesUnderTest.set_tractor_implement_management_server_option_state(ControlFunctionFunctionalities::TractorImplementManagementOptions::FrontPTOEngagementCCWIsSupported, true);
+
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::MinimumControlFunction));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::UniversalTerminalServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::UniversalTerminalWorkingSet));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxOInputs));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxOFunctions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNInputs));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNFunctions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerBasicServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerBasicClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerGeoServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerGeoClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUImplementClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementClient));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::FileServer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::FileServerClient));
+
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_N_functions_option_state(ControlFunctionFunctionalities::AuxNOptions::SupportsType8Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_N_inputs_option_state(ControlFunctionFunctionalities::AuxNOptions::SupportsType9Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(0, cfFunctionalitiesUnderTest.get_task_controller_geo_client_option());
+	EXPECT_EQ(0, cfFunctionalitiesUnderTest.get_task_controller_section_control_server_number_supported_booms());
+	EXPECT_EQ(0, cfFunctionalitiesUnderTest.get_task_controller_section_control_server_number_supported_sections());
+	EXPECT_EQ(0, cfFunctionalitiesUnderTest.get_tractor_implement_management_client_aux_valve_flow_supported(4));
+	EXPECT_EQ(0, cfFunctionalitiesUnderTest.get_tractor_implement_management_client_aux_valve_state_supported(4));
+	EXPECT_EQ(0, cfFunctionalitiesUnderTest.get_tractor_implement_management_server_aux_valve_flow_supported(6));
+	EXPECT_EQ(0, cfFunctionalitiesUnderTest.get_tractor_implement_management_server_aux_valve_state_supported(6));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_tractor_implement_management_client_option_state(ControlFunctionFunctionalities::TractorImplementManagementOptions::FrontPTOengagementCWIsSupported));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_tractor_implement_management_server_option_state(ControlFunctionFunctionalities::TractorImplementManagementOptions::FrontPTOEngagementCCWIsSupported));
+
+	// Min CF functionality should still be enabled by default
+	EXPECT_EQ(1, cfFunctionalitiesUnderTest.get_functionality_generation(ControlFunctionFunctionalities::Functionalities::MinimumControlFunction));
+
+	// Our weak termination should be supported
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination));
+
+	// Test Min CF functionalities
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatConsumer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatProducer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::NoOptions));
+
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination, false);
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatConsumer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatProducer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::NoOptions));
+
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination, false);
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatConsumer, true);
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatConsumer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatProducer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::NoOptions));
+
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatConsumer, false);
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatProducer, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatConsumer));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatProducer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::NoOptions));
+
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatProducer, false);
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatConsumer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatProducer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::NoOptions));
+
+	cfFunctionalitiesUnderTest.set_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination, false);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatConsumer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::SupportOfHeartbeatProducer));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type2ECUInternalEndPointTermination));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_minimum_control_function_option_state(ControlFunctionFunctionalities::MinimumControlFunctionOptions::NoOptions));
+
+	// Test the combinations of AUX-O Inputs
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxOInputs, 1, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+
+	cfFunctionalitiesUnderTest.set_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+
+	cfFunctionalitiesUnderTest.set_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function, false);
+	cfFunctionalitiesUnderTest.set_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+
+	cfFunctionalitiesUnderTest.set_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function, false);
+	cfFunctionalitiesUnderTest.set_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+
+	cfFunctionalitiesUnderTest.set_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function, false);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_inputs_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxOInputs, 1, false);
+
+	// Test the combinations of AUX-O functions
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxOFunctions, 1, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+
+	cfFunctionalitiesUnderTest.set_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+
+	cfFunctionalitiesUnderTest.set_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function, false);
+	cfFunctionalitiesUnderTest.set_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+
+	cfFunctionalitiesUnderTest.set_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function, false);
+	cfFunctionalitiesUnderTest.set_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+
+	cfFunctionalitiesUnderTest.set_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function, false);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::Reserved));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType0Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType1Function));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_O_functions_option_state(ControlFunctionFunctionalities::AuxOOptions::SupportsType2Function));
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxOFunctions, 1, false);
+
+	// Test the combinations of AUX-N Inputs
+	auto aux_n_inputs_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::AuxNOptions functionalityOption) {
+		bool retVal = true;
+
+		for (std::uint32_t i = 1; i <= 0x80; i = i << 1)
+		{
+			if (static_cast<ControlFunctionFunctionalities::AuxNOptions>(i) == functionalityOption)
+			{
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_aux_N_inputs_option_state(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i)));
+			}
+			else
+			{
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_N_inputs_option_state(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i)));
+			}
+		}
+		return retVal;
+	};
+
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNInputs, 1, true);
+	for (std::uint8_t i = static_cast<std::uint8_t>(ControlFunctionFunctionalities::AuxNOptions::SupportsType0Function); i != static_cast<std::uint8_t>(ControlFunctionFunctionalities::AuxNOptions::SupportsType14Function); i = i << 1)
+	{
+		cfFunctionalitiesUnderTest.set_aux_N_inputs_option_state(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i), true);
+		aux_n_inputs_test_wrapper(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i));
+		cfFunctionalitiesUnderTest.set_aux_N_inputs_option_state(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i), false);
+	}
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNInputs, 1, false);
+
+	// Test the combinations of AUX-N Functions
+	auto aux_n_functions_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::AuxNOptions functionalityOption) {
+		bool retVal = true;
+
+		for (std::uint32_t i = 1; i <= 0x80; i = i << 1)
+		{
+			if (static_cast<ControlFunctionFunctionalities::AuxNOptions>(i) == functionalityOption)
+			{
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_aux_N_functions_option_state(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i)));
+			}
+			else
+			{
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_aux_N_functions_option_state(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i)));
+			}
+		}
+		return retVal;
+	};
+
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNFunctions, 1, true);
+	for (std::uint8_t i = static_cast<std::uint8_t>(ControlFunctionFunctionalities::AuxNOptions::SupportsType0Function); i != static_cast<std::uint8_t>(ControlFunctionFunctionalities::AuxNOptions::SupportsType14Function); i = i << 1)
+	{
+		cfFunctionalitiesUnderTest.set_aux_N_functions_option_state(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i), true);
+		aux_n_functions_test_wrapper(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i));
+		cfFunctionalitiesUnderTest.set_aux_N_functions_option_state(static_cast<ControlFunctionFunctionalities::AuxNOptions>(i), false);
+	}
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNFunctions, 1, false);
+
+	// Test TC GEO Server
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerGeoServer, 1, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_task_controller_geo_server_option_state(ControlFunctionFunctionalities::TaskControllerGeoServerOptions::NoOptions));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_task_controller_geo_server_option_state(ControlFunctionFunctionalities::TaskControllerGeoServerOptions::PolygonBasedPrescriptionMapsAreSupported));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_task_controller_geo_server_option_state(ControlFunctionFunctionalities::TaskControllerGeoServerOptions::Reserved));
+
+	cfFunctionalitiesUnderTest.set_task_controller_geo_server_option_state(ControlFunctionFunctionalities::TaskControllerGeoServerOptions::PolygonBasedPrescriptionMapsAreSupported, true);
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_task_controller_geo_server_option_state(ControlFunctionFunctionalities::TaskControllerGeoServerOptions::NoOptions));
+	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_task_controller_geo_server_option_state(ControlFunctionFunctionalities::TaskControllerGeoServerOptions::PolygonBasedPrescriptionMapsAreSupported));
+	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_task_controller_geo_server_option_state(ControlFunctionFunctionalities::TaskControllerGeoServerOptions::Reserved));
+	cfFunctionalitiesUnderTest.set_task_controller_geo_server_option_state(ControlFunctionFunctionalities::TaskControllerGeoServerOptions::PolygonBasedPrescriptionMapsAreSupported, false);
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerGeoServer, 1, false);
+
+	// Test TC GEO Client
+	EXPECT_EQ(0, cfFunctionalitiesUnderTest.get_task_controller_geo_client_option());
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerGeoClient, 1, true);
+	EXPECT_EQ(0, cfFunctionalitiesUnderTest.get_task_controller_geo_client_option());
+	cfFunctionalitiesUnderTest.set_task_controller_geo_client_option(125);
+	EXPECT_EQ(125, cfFunctionalitiesUnderTest.get_task_controller_geo_client_option());
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerGeoClient, 1, false);
+
+	// Test TC section control server functionalities
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlServer, 1, true);
+	EXPECT_EQ(1, cfFunctionalitiesUnderTest.get_task_controller_section_control_server_number_supported_booms());
+	EXPECT_EQ(1, cfFunctionalitiesUnderTest.get_task_controller_section_control_server_number_supported_sections());
+	cfFunctionalitiesUnderTest.set_task_controller_section_control_server_option_state(123, 211);
+	EXPECT_EQ(123, cfFunctionalitiesUnderTest.get_task_controller_section_control_server_number_supported_booms());
+	EXPECT_EQ(211, cfFunctionalitiesUnderTest.get_task_controller_section_control_server_number_supported_sections());
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlServer, 1, false);
+
+	// Test TC section control client functionalities
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlClient, 1, true);
+	EXPECT_EQ(1, cfFunctionalitiesUnderTest.get_task_controller_section_control_client_number_supported_booms());
+	EXPECT_EQ(1, cfFunctionalitiesUnderTest.get_task_controller_section_control_client_number_supported_sections());
+	cfFunctionalitiesUnderTest.set_task_controller_section_control_client_option_state(123, 211);
+	EXPECT_EQ(123, cfFunctionalitiesUnderTest.get_task_controller_section_control_client_number_supported_booms());
+	EXPECT_EQ(211, cfFunctionalitiesUnderTest.get_task_controller_section_control_client_number_supported_sections());
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlClient, 1, false);
+
+	// Test the combinations of Basic Tractor ECU Server Functions
+	auto basic_tecu_server_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::BasicTractorECUOptions functionalityOption) {
+		bool retVal = true;
+
+		for (std::uint32_t i = 1; i <= 0x20; i = i << 1)
+		{
+			if (static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i) == functionalityOption)
+			{
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_basic_tractor_ECU_server_option_state(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i)));
+			}
+			else
+			{
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_basic_tractor_ECU_server_option_state(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i)));
+			}
+		}
+		return retVal;
+	};
+
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUServer, 1, true);
+	for (std::uint8_t i = static_cast<std::uint8_t>(ControlFunctionFunctionalities::BasicTractorECUOptions::Class1NoOptions); i <= 0x20; i = i << 1)
+	{
+		cfFunctionalitiesUnderTest.set_basic_tractor_ECU_server_option_state(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i), true);
+		basic_tecu_server_test_wrapper(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i));
+		cfFunctionalitiesUnderTest.set_basic_tractor_ECU_server_option_state(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i), false);
+	}
+	EXPECT_TRUE(cfFunctionalitiesUnderTest.get_basic_tractor_ECU_server_option_state(ControlFunctionFunctionalities::BasicTractorECUOptions::TECUNotMeetingCompleteClass1Requirements));
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUServer, 1, false);
+
+	// Test the combinations of Basic Tractor ECU Client Functions
+	auto basic_tecu_client_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::BasicTractorECUOptions functionalityOption) {
+		bool retVal = true;
+
+		for (std::uint32_t i = 1; i <= 0x20; i = i << 1)
+		{
+			if (static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i) == functionalityOption)
+			{
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_basic_tractor_ECU_implement_client_option_state(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i)));
+			}
+			else
+			{
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_basic_tractor_ECU_implement_client_option_state(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i)));
+			}
+		}
+		return retVal;
+	};
+
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUImplementClient, 1, true);
+	for (std::uint8_t i = static_cast<std::uint8_t>(ControlFunctionFunctionalities::BasicTractorECUOptions::Class1NoOptions); i <= 0x20; i = i << 1)
+	{
+		cfFunctionalitiesUnderTest.set_basic_tractor_ECU_implement_client_option_state(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i), true);
+		basic_tecu_client_test_wrapper(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i));
+		cfFunctionalitiesUnderTest.set_basic_tractor_ECU_implement_client_option_state(static_cast<ControlFunctionFunctionalities::BasicTractorECUOptions>(i), false);
+	}
+	EXPECT_TRUE(cfFunctionalitiesUnderTest.get_basic_tractor_ECU_implement_client_option_state(ControlFunctionFunctionalities::BasicTractorECUOptions::TECUNotMeetingCompleteClass1Requirements));
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUImplementClient, 1, false);
+
+	// Test TIM server options
+	auto tim_server_options_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::TractorImplementManagementOptions functionalityOption) {
+		bool retVal = true;
+
+		for (std::uint_fast8_t i = 1; i <= static_cast<std::uint_fast8_t>(ControlFunctionFunctionalities::TractorImplementManagementOptions::GuidanceCurvatureIsSupported); i++)
+		{
+			if (static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i) == functionalityOption)
+			{
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_tractor_implement_management_server_option_state(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i)));
+			}
+			else
+			{
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_tractor_implement_management_server_option_state(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i)));
+			}
+		}
+		return retVal;
+	};
+
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementServer, 1, true);
+	for (std::uint8_t i = static_cast<std::uint8_t>(ControlFunctionFunctionalities::TractorImplementManagementOptions::NoOptions); i <= static_cast<std::uint8_t>(ControlFunctionFunctionalities::TractorImplementManagementOptions::GuidanceCurvatureIsSupported); i++)
+	{
+		cfFunctionalitiesUnderTest.set_tractor_implement_management_server_option_state(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i), true);
+		tim_server_options_test_wrapper(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i));
+		cfFunctionalitiesUnderTest.set_tractor_implement_management_server_option_state(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i), false);
+	}
+	EXPECT_TRUE(cfFunctionalitiesUnderTest.get_tractor_implement_management_server_option_state(ControlFunctionFunctionalities::TractorImplementManagementOptions::NoOptions));
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementServer, 1, false);
+
+	// Test TIM client options
+	auto tim_client_options_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::TractorImplementManagementOptions functionalityOption) {
+		bool retVal = true;
+
+		for (std::uint_fast8_t i = 1; i <= static_cast<std::uint_fast8_t>(ControlFunctionFunctionalities::TractorImplementManagementOptions::GuidanceCurvatureIsSupported); i++)
+		{
+			if (static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i) == functionalityOption)
+			{
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_tractor_implement_management_client_option_state(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i)));
+			}
+			else
+			{
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_tractor_implement_management_client_option_state(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i)));
+			}
+		}
+		return retVal;
+	};
+
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementClient, 1, true);
+	for (std::uint8_t i = static_cast<std::uint8_t>(ControlFunctionFunctionalities::TractorImplementManagementOptions::NoOptions); i <= static_cast<std::uint8_t>(ControlFunctionFunctionalities::TractorImplementManagementOptions::GuidanceCurvatureIsSupported); i++)
+	{
+		cfFunctionalitiesUnderTest.set_tractor_implement_management_client_option_state(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i), true);
+		tim_client_options_test_wrapper(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i));
+		cfFunctionalitiesUnderTest.set_tractor_implement_management_client_option_state(static_cast<ControlFunctionFunctionalities::TractorImplementManagementOptions>(i), false);
+	}
+	EXPECT_TRUE(cfFunctionalitiesUnderTest.get_tractor_implement_management_client_option_state(ControlFunctionFunctionalities::TractorImplementManagementOptions::NoOptions));
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementClient, 1, false);
+
+	// Test TIM client aux valve states
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementClient, 1, true);
+
+	for (std::uint8_t i = 0; i < 32; i++)
+	{
+		cfFunctionalitiesUnderTest.set_tractor_implement_management_client_aux_valve_option(i, true, true);
+		for (std::uint8_t j = 0; j < 32; j++)
+		{
+			if (i == j)
+			{
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_tractor_implement_management_client_aux_valve_flow_supported(j));
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_tractor_implement_management_client_aux_valve_state_supported(j));
+			}
+			else
+			{
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_tractor_implement_management_client_aux_valve_flow_supported(j));
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_tractor_implement_management_client_aux_valve_state_supported(j));
+			}
+		}
+		cfFunctionalitiesUnderTest.set_tractor_implement_management_client_aux_valve_option(i, false, false);
+	}
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementClient, 1, false);
+
+	// Test TIM Server aux valve states
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementServer, 1, true);
+
+	for (std::uint8_t i = 0; i < 32; i++)
+	{
+		cfFunctionalitiesUnderTest.set_tractor_implement_management_server_aux_valve_option(i, true, true);
+		for (std::uint8_t j = 0; j < 32; j++)
+		{
+			if (i == j)
+			{
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_tractor_implement_management_server_aux_valve_flow_supported(j));
+				EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_tractor_implement_management_server_aux_valve_state_supported(j));
+			}
+			else
+			{
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_tractor_implement_management_server_aux_valve_flow_supported(j));
+				EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_tractor_implement_management_server_aux_valve_state_supported(j));
+			}
+		}
+		cfFunctionalitiesUnderTest.set_tractor_implement_management_server_aux_valve_option(i, false, false);
+	}
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementServer, 1, false);
 
 	// Get the virtual CAN plugin back to a known state
 	while (!requesterPlugin.get_queue_empty())
@@ -59,5 +532,98 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, asdf)
 	}
 	ASSERT_TRUE(requesterPlugin.get_queue_empty());
 
-	ControlFunctionFunctionalities cfFunctionalitiesUnderTest(internalECU);
+	// Simulate a request for the message
+	testFrame.identifier = 0x18EA50F7;
+	testFrame.data[0] = 0x8E;
+	testFrame.data[1] = 0xFC;
+	testFrame.data[2] = 0x00;
+	testFrame.dataLength = 3;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+	CANNetworkManager::CANNetwork.update(); // Update twice in case the order of the protocols is different, causing a slight delay
+
+	ASSERT_TRUE(requesterPlugin.read_frame(testFrame));
+	ASSERT_TRUE(testFrame.isExtendedFrame);
+
+	// If we got a message, we will assume it's OK and validate the message buffer instead, since the payload is probably BAM
+	CANHardwareInterface::stop();
+
+	std::vector<std::uint8_t> testMessageData;
+
+	cfFunctionalitiesUnderTest.test_wrapper_get_message_content(testMessageData);
+
+	// We should just have the minimum CF functionalities
+	ASSERT_EQ(8, testMessageData.size());
+	EXPECT_EQ(0xFF, testMessageData.at(0)); // Each control function shall respond with byte 1 set to FF16
+	EXPECT_EQ(1, testMessageData.at(1)); // We are reporting 1 functionality
+	EXPECT_EQ(0, testMessageData.at(2)); // Functionality 0 is min CF
+	EXPECT_EQ(1, testMessageData.at(3)); // We specify generation 1 by default
+	EXPECT_EQ(1, testMessageData.at(4)); // 1 Option byte
+	EXPECT_EQ(0, testMessageData.at(5)); // No options
+	EXPECT_EQ(0xFF, testMessageData.at(6)); // 0xFF Padding to 8 bytes
+	EXPECT_EQ(0xFF, testMessageData.at(7)); // 0xFF Padding to 8 bytes
+
+	// Say we are a UT working set
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::UniversalTerminalWorkingSet, 1, true);
+	cfFunctionalitiesUnderTest.test_wrapper_get_message_content(testMessageData);
+
+	// We should just have the minimum CF functionalities PLUS the UT client
+	ASSERT_EQ(10, testMessageData.size());
+	EXPECT_EQ(0xFF, testMessageData.at(0)); // Each control function shall respond with byte 1 set to FF16
+	EXPECT_EQ(2, testMessageData.at(1)); // We are reporting 2 functionalities
+	EXPECT_EQ(0, testMessageData.at(2)); // Functionality 0 is min CF
+	EXPECT_EQ(1, testMessageData.at(3)); // We specify generation 1 by default
+	EXPECT_EQ(1, testMessageData.at(4)); // 1 Option byte
+	EXPECT_EQ(0, testMessageData.at(5)); // No options
+	EXPECT_EQ(2, testMessageData.at(6)); // UT working set
+	EXPECT_EQ(1, testMessageData.at(7)); // Generation 1. These generations are seemingly user defined and arbitrary, not the ISO standard version... no SPN defined...
+	EXPECT_EQ(1, testMessageData.at(8)); // 1 Option byte
+	EXPECT_EQ(0, testMessageData.at(9)); // No options
+
+	// Add Aux-N
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNFunctions, 1, true);
+	cfFunctionalitiesUnderTest.test_wrapper_get_message_content(testMessageData);
+	ASSERT_EQ(15, testMessageData.size());
+	EXPECT_EQ(0xFF, testMessageData.at(0)); // Each control function shall respond with byte 1 set to FF16
+	EXPECT_EQ(3, testMessageData.at(1)); // We are reporting 3 functionalities
+	EXPECT_EQ(0, testMessageData.at(2)); // Functionality 0 is min CF
+	EXPECT_EQ(1, testMessageData.at(3)); // We specify generation 1 by default
+	EXPECT_EQ(1, testMessageData.at(4)); // 1 Option byte
+	EXPECT_EQ(0, testMessageData.at(5)); // No options
+	EXPECT_EQ(2, testMessageData.at(6)); // UT working set
+	EXPECT_EQ(1, testMessageData.at(7)); // Generation 1. These generations are seemingly user defined and arbitrary, not the ISO standard version... no SPN defined...
+	EXPECT_EQ(1, testMessageData.at(8)); // 1 Option byte
+	EXPECT_EQ(0, testMessageData.at(9)); // No options
+	EXPECT_EQ(6, testMessageData.at(10)); // Functionality 6 is AUX N functions
+	EXPECT_EQ(1, testMessageData.at(11)); // We specify generation 1
+	EXPECT_EQ(2, testMessageData.at(12)); // 2 Option bytes
+	EXPECT_EQ(0, testMessageData.at(13)); // No options
+	EXPECT_EQ(0, testMessageData.at(14)); // No options
+
+	// Add Task controller Client
+	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlClient, 1, true);
+	cfFunctionalitiesUnderTest.set_task_controller_section_control_client_option_state(1, 255); // 1 Boom, 255 sections
+	cfFunctionalitiesUnderTest.test_wrapper_get_message_content(testMessageData);
+
+	ASSERT_EQ(20, testMessageData.size());
+	EXPECT_EQ(0xFF, testMessageData.at(0)); // Each control function shall respond with byte 1 set to FF16
+	EXPECT_EQ(4, testMessageData.at(1)); // We are reporting 4 functionalities
+	EXPECT_EQ(0, testMessageData.at(2)); // Functionality 0 is min CF
+	EXPECT_EQ(1, testMessageData.at(3)); // We specify generation 1 by default
+	EXPECT_EQ(1, testMessageData.at(4)); // 1 Option byte
+	EXPECT_EQ(0, testMessageData.at(5)); // No options
+	EXPECT_EQ(2, testMessageData.at(6)); // UT working set
+	EXPECT_EQ(1, testMessageData.at(7)); // Generation 1. These generations are seemingly user defined and arbitrary, not the ISO standard version... no SPN defined...
+	EXPECT_EQ(1, testMessageData.at(8)); // 1 Option byte
+	EXPECT_EQ(0, testMessageData.at(9)); // No options
+	EXPECT_EQ(6, testMessageData.at(10)); // Functionality 6 is AUX N functions
+	EXPECT_EQ(1, testMessageData.at(11)); // We specify generation 1
+	EXPECT_EQ(2, testMessageData.at(12)); // 2 Option bytes
+	EXPECT_EQ(0, testMessageData.at(13)); // No options
+	EXPECT_EQ(0, testMessageData.at(14)); // No options
+	EXPECT_EQ(12, testMessageData.at(15)); // Functionality 12 is TC section control client
+	EXPECT_EQ(1, testMessageData.at(16)); // We specify generation 1
+	EXPECT_EQ(2, testMessageData.at(17)); // 2 Option bytes
+	EXPECT_EQ(1, testMessageData.at(18)); // 1 Boom
+	EXPECT_EQ(255, testMessageData.at(19)); // 255 Sections
 }

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -540,7 +540,8 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	testFrame.dataLength = 3;
 	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	CANNetworkManager::CANNetwork.update(); // Update twice in case the order of the protocols is different, causing a slight delay
+
+	cfFunctionalitiesUnderTest.update(); // Updating manually since we're not integrated with the diagnostic protocol inside this test
 
 	ASSERT_TRUE(requesterPlugin.read_frame(testFrame));
 	ASSERT_TRUE(testFrame.isExtendedFrame);

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+
+#include "isobus/hardware_integration/can_hardware_interface.hpp"
+#include "isobus/hardware_integration/virtual_can_plugin.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
+#include "isobus/isobus/isobus_functionalities.hpp"
+#include "isobus/utility/system_timing.hpp"
+
+using namespace isobus;
+
+TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, asdf)
+{
+	VirtualCANPlugin requesterPlugin;
+	requesterPlugin.open();
+
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
+	CANHardwareInterface::start();
+
+	NAME clientNAME(0);
+	clientNAME.set_industry_group(2);
+	clientNAME.set_function_instance(3);
+	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::TirePressureControl));
+	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x50, 0);
+
+	HardwareInterfaceCANFrame testFrame;
+
+	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
+
+	while ((!internalECU->get_address_valid()) &&
+	       (!SystemTiming::time_expired_ms(waitingTimestamp_ms, 2000)))
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+
+	ASSERT_TRUE(internalECU->get_address_valid());
+
+	// Force claim a partner
+	testFrame.dataLength = 8;
+	testFrame.channel = 0;
+	testFrame.isExtendedFrame = true;
+	testFrame.identifier = 0x18EEFFF7;
+	testFrame.data[0] = 0x03;
+	testFrame.data[1] = 0x04;
+	testFrame.data[2] = 0x00;
+	testFrame.data[3] = 0x12;
+	testFrame.data[4] = 0x00;
+	testFrame.data[5] = 0x82;
+	testFrame.data[6] = 0x00;
+	testFrame.data[7] = 0xA0;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	// Get the virtual CAN plugin back to a known state
+	while (!requesterPlugin.get_queue_empty())
+	{
+		requesterPlugin.read_frame(testFrame);
+	}
+	ASSERT_TRUE(requesterPlugin.get_queue_empty());
+
+	ControlFunctionFunctionalities cfFunctionalitiesUnderTest(internalECU);
+}


### PR DESCRIPTION
## What's new

* This adds support for sending the CF Functionalities message as part of the diagnostic protocol class.
* The new class will automatically respond to requests from ANY ecu, either as a broadcast or point-to-point for the "Control Function Functionalities" PGN (0xFC8E, 64654)
* ISOBUS ECUs are required to support this message, so by default, we will report every consumer of our library as a "Minimum Control Function" of "generation 1" unless configured otherwise (if you are using the diagnostic protocol).
* In general you will want your application to configure this appropriately for what you are using. If you are using the VT client, you should configure this message to send "Universal Terminal Working Set" as supported. If you are using the TC client, same thing, you will want to report you are a "Task Controller Section Control Client" with the appropriate data such as number of booms and sections supported. There are several functionalities to be aware of!
* The functionalities are documented here https://www.isobus.net/isobus/option
* The PGN is loosely defined here https://www.isobus.net/isobus/pGNAndSPN/10250 but mostly just says refer to ISO11783-12