### PR TITLE
[Core]: Add support for J1939/ISOBUS commanded address message

### DIFF
--- a/isobus/include/isobus/isobus/can_address_claim_state_machine.hpp
+++ b/isobus/include/isobus/isobus/can_address_claim_state_machine.hpp
@@ -56,6 +56,12 @@ namespace isobus
 		/// @returns The current state of the state machine
 		State get_current_state() const;
 
+		/// @brief Attempts to process a commanded address.
+		/// @details If the state machine has claimed successfully before,
+		/// this will attempt to move a NAME from the claimed address to the new, specified address.
+		/// @param[in] commandedAddress The address to attempt to claim
+		void process_commanded_address(std::uint8_t commandedAddress);
+
 		/// @brief Enables or disables the address claimer
 		/// @param[in] value true if you want the class to claim, false if you want to be a sniffer only
 		void set_is_enabled(bool value);

--- a/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
@@ -39,6 +39,7 @@ namespace isobus
 		DiagnosticMessage2 = 0xFECB,
 		DiagnosticMessage3 = 0xFECC,
 		DiagnosticMessage11 = 0xFED3,
+		CommandedAddress = 0xFED8,
 		SoftwareIdentification = 0xFEDA,
 		AllImplementsStopOperationsSwitchState = 0xFD02
 	};

--- a/isobus/include/isobus/isobus/can_internal_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_internal_control_function.hpp
@@ -59,6 +59,10 @@ namespace isobus
 		/// @returns true if the ICF changed address since the last network manager update
 		bool get_changed_address_since_last_update(CANLibBadge<CANNetworkManager>) const;
 
+		/// @brief Used by the network manager to tell the ICF that the address claim state machine needs to process
+		/// a J1939 command to move address.
+		void process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>);
+
 		/// @brief Updates all address claim state machines
 		static void update_address_claiming(CANLibBadge<CANNetworkManager>);
 

--- a/isobus/include/isobus/isobus/can_message.hpp
+++ b/isobus/include/isobus/isobus/can_message.hpp
@@ -84,7 +84,7 @@ namespace isobus
 		/// @details This function will return the byte at the specified index in the buffer.
 		/// @param[in] index The index to get the byte from
 		/// @return The 8-bit unsigned byte
-		std::uint8_t get_uint8_at(const std::size_t index);
+		std::uint8_t get_uint8_at(const std::size_t index) const;
 
 		/// @brief Get a 16-bit unsigned integer from the buffer at a specific index.
 		/// A 16-bit unsigned integer can hold a value between 0 and 65535.
@@ -92,7 +92,7 @@ namespace isobus
 		/// @param[in] index The index to get the 16-bit unsigned integer from
 		/// @param[in] format The byte format to use when reading the integer
 		/// @return The 16-bit unsigned integer
-		std::uint16_t get_uint16_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian);
+		std::uint16_t get_uint16_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
 
 		/// @brief Get a right-aligned 24-bit integer from the buffer (returned as a uint32_t) at a specific index.
 		/// A 24-bit number can hold a value between 0 and 16,777,215.
@@ -100,7 +100,7 @@ namespace isobus
 		/// @param[in] index The index to get the 24-bit unsigned integer from
 		/// @param[in] format The byte format to use when reading the integer
 		/// @return The 24-bit unsigned integer, right aligned into a uint32_t
-		std::uint32_t get_uint24_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian);
+		std::uint32_t get_uint24_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
 
 		/// @brief Get a 32-bit unsigned integer from the buffer at a specific index.
 		/// A 32-bit unsigned integer can hold a value between 0 and 4294967295.
@@ -108,7 +108,7 @@ namespace isobus
 		/// @param[in] index The index to get the 32-bit unsigned integer from
 		/// @param[in] format The byte format to use when reading the integer
 		/// @return The 32-bit unsigned integer
-		std::uint32_t get_uint32_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian);
+		std::uint32_t get_uint32_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
 
 		/// @brief Get a 64-bit unsigned integer from the buffer at a specific index.
 		/// A 64-bit unsigned integer can hold a value between 0 and 18446744073709551615.
@@ -116,7 +116,7 @@ namespace isobus
 		/// @param[in] index The index to get the 64-bit unsigned integer from
 		/// @param[in] format The byte format to use when reading the integer
 		/// @return The 64-bit unsigned integer
-		std::uint64_t get_uint64_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian);
+		std::uint64_t get_uint64_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
 
 		/// @brief Get a bit-boolean from the buffer at a specific index.
 		/// @details This function will return whether the bit(s) at the specified index in the buffer is/are (all) equal to 1.
@@ -124,7 +124,7 @@ namespace isobus
 		/// @param[in] bitIndex The bit index to start reading the boolean from, ranging from 0 to 7
 		/// @param[in] length The number of bits to read, maximum of (8 - bitIndex)
 		/// @return True if (all) the bit(s) are set, false otherwise
-		bool get_bool_at(const std::size_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length = 1);
+		bool get_bool_at(const std::size_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length = 1) const;
 
 		/// @brief ISO11783-3 defines this: The maximum number of packets that can be sent in a single connection
 		/// with extended transport protocol is restricted by the extended data packet offset (3 bytes).

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -256,6 +256,13 @@ namespace isobus
 		/// @param[in] message A pointer to a CAN message to be processed
 		void process_can_message_for_global_and_partner_callbacks(CANMessage *message);
 
+		/// @brief Processes a CAN message to see if it's a commanded address message, and
+		/// if it is, it attempts to set the relevant CF's address to the new value.
+		/// @note Changing the address will resend the address claim message if
+		/// the target was an internal control function.
+		/// @param[in] message The message to process
+		void process_can_message_for_commanded_address(const CANMessage *message);
+
 		/// @brief Processes the internal receive message queue
 		void process_rx_messages();
 

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -80,6 +80,11 @@ namespace isobus
 		return objectChangedAddressSinceLastUpdate;
 	}
 
+	void InternalControlFunction::process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>)
+	{
+		stateMachine.process_commanded_address(commandedAddress);
+	}
+
 	void InternalControlFunction::update_address_claiming(CANLibBadge<CANNetworkManager>)
 	{
 		anyChangedAddress = false;

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -63,12 +63,12 @@ namespace isobus
 		return CANPortIndex;
 	}
 
-	std::uint8_t CANMessage::get_uint8_at(const std::size_t index)
+	std::uint8_t CANMessage::get_uint8_at(const std::size_t index) const
 	{
 		return data.at(index);
 	}
 
-	std::uint16_t CANMessage::get_uint16_at(const std::size_t index, const ByteFormat format)
+	std::uint16_t CANMessage::get_uint16_at(const std::size_t index, const ByteFormat format) const
 	{
 		std::uint16_t retVal;
 		if (ByteFormat::LittleEndian == format)
@@ -84,7 +84,7 @@ namespace isobus
 		return retVal;
 	}
 
-	std::uint32_t CANMessage::get_uint24_at(const std::size_t index, const ByteFormat format)
+	std::uint32_t CANMessage::get_uint24_at(const std::size_t index, const ByteFormat format) const
 	{
 		std::uint32_t retVal;
 		if (ByteFormat::LittleEndian == format)
@@ -102,7 +102,7 @@ namespace isobus
 		return retVal;
 	}
 
-	std::uint32_t CANMessage::get_uint32_at(const std::size_t index, const ByteFormat format)
+	std::uint32_t CANMessage::get_uint32_at(const std::size_t index, const ByteFormat format) const
 	{
 		std::uint32_t retVal;
 		if (ByteFormat::LittleEndian == format)
@@ -122,7 +122,7 @@ namespace isobus
 		return retVal;
 	}
 
-	std::uint64_t CANMessage::get_uint64_at(const std::size_t index, const ByteFormat format)
+	std::uint64_t CANMessage::get_uint64_at(const std::size_t index, const ByteFormat format) const
 	{
 		std::uint64_t retVal;
 		if (ByteFormat::LittleEndian == format)
@@ -149,7 +149,7 @@ namespace isobus
 		}
 		return retVal;
 	}
-	bool isobus::CANMessage::get_bool_at(const std::size_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length)
+	bool isobus::CANMessage::get_bool_at(const std::size_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length) const
 	{
 		assert(length <= 8 - bitIndex && "length must be less than or equal to 8 - bitIndex");
 		std::uint8_t mask = ((1 << length) - 1) << bitIndex;

--- a/test/core_network_management_tests.cpp
+++ b/test/core_network_management_tests.cpp
@@ -1,8 +1,11 @@
 #include <gtest/gtest.h>
 
+#include "isobus/hardware_integration/can_hardware_interface.hpp"
+#include "isobus/hardware_integration/virtual_can_plugin.hpp"
 #include "isobus/isobus/can_internal_control_function.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_partnered_control_function.hpp"
+#include "isobus/utility/system_timing.hpp"
 
 #include <memory>
 #include <thread>
@@ -69,4 +72,100 @@ TEST(CORE_TESTS, BusloadTest)
 	// Bus load should be non zero, and less than 100%
 	EXPECT_NE(0.0f, CANNetworkManager::CANNetwork.get_estimated_busload(0));
 	EXPECT_LT(CANNetworkManager::CANNetwork.get_estimated_busload(0), 100.0f);
+}
+
+TEST(CORE_TESTS, CommandedAddress)
+{
+	VirtualCANPlugin testPlugin;
+	testPlugin.open();
+
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
+	CANHardwareInterface::start();
+
+	isobus::NAME TestDeviceNAME(0);
+	TestDeviceNAME.set_arbitrary_address_capable(true);
+	TestDeviceNAME.set_industry_group(3);
+	TestDeviceNAME.set_device_class(4);
+	TestDeviceNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::FuelPropertiesSensor));
+	TestDeviceNAME.set_identity_number(2);
+	TestDeviceNAME.set_ecu_instance(1);
+	TestDeviceNAME.set_function_instance(0);
+	TestDeviceNAME.set_device_class_instance(0);
+	TestDeviceNAME.set_manufacturer_code(64);
+
+	auto testECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x43, 0);
+
+	HardwareInterfaceCANFrame testFrame;
+
+	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
+
+	while ((!testECU->get_address_valid()) &&
+	       (!SystemTiming::time_expired_ms(waitingTimestamp_ms, 2000)))
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+
+	ASSERT_TRUE(testECU->get_address_valid());
+
+	// Force claim some other ECU
+	testFrame.dataLength = 8;
+	testFrame.channel = 0;
+	testFrame.isExtendedFrame = true;
+	testFrame.identifier = 0x18EEFFF8;
+	testFrame.data[0] = 0x03;
+	testFrame.data[1] = 0x04;
+	testFrame.data[2] = 0x00;
+	testFrame.data[3] = 0x02;
+	testFrame.data[4] = 0x00;
+	testFrame.data[5] = 0x89;
+	testFrame.data[6] = 0x00;
+	testFrame.data[7] = 0xA0;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+
+	// Let's construct a short BAM session for commanded address
+	// We'll ignore the 50ms timing for the unit test
+
+	testFrame.identifier = 0x18ECFFF8; // TP Command broadcast
+	testFrame.data[0] = 0x20; // BAM Mux
+	testFrame.data[1] = 9; // Data Length
+	testFrame.data[2] = 0; // Data Length MSB
+	testFrame.data[3] = 2; // Packet count
+	testFrame.data[4] = 0xFF; // Reserved
+	testFrame.data[5] = 0xD8; // PGN LSB
+	testFrame.data[6] = 0xFE; // PGN middle byte
+	testFrame.data[7] = 0x00; // PGN MSB
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+
+	std::uint64_t rawNAME = testECU->get_NAME().get_full_name();
+
+	// data packet 1
+	testFrame.identifier = 0x18EBFFF8;
+	testFrame.data[0] = 1;
+	testFrame.data[1] = static_cast<std::uint8_t>(rawNAME & 0xFF);
+	testFrame.data[2] = static_cast<std::uint8_t>((rawNAME >> 8) & 0xFF);
+	testFrame.data[3] = static_cast<std::uint8_t>((rawNAME >> 16) & 0xFF);
+	testFrame.data[4] = static_cast<std::uint8_t>((rawNAME >> 24) & 0xFF);
+	testFrame.data[5] = static_cast<std::uint8_t>((rawNAME >> 32) & 0xFF);
+	testFrame.data[6] = static_cast<std::uint8_t>((rawNAME >> 40) & 0xFF);
+	testFrame.data[7] = static_cast<std::uint8_t>((rawNAME >> 48) & 0xFF);
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+
+	// data packet 2
+	testFrame.data[0] = 2;
+	testFrame.data[1] = static_cast<std::uint8_t>((rawNAME >> 56) & 0xFF);
+	testFrame.data[2] = 0x04; // Address
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0xFF;
+	testFrame.data[7] = 0xFF;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(500));
+	EXPECT_EQ(0x04, testECU->get_address());
+	testPlugin.close();
+	CANHardwareInterface::stop();
 }


### PR DESCRIPTION
* Added processing and use of the commanded address PGN. 
* Changed some CAN message getters to be const.