### PR TITLE
[#245]: Moved NMEA2k fast packet protocol instance to the network manager

### DIFF
--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -46,7 +46,7 @@ int main()
 
 	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
+	canDriver = std::make_shared<isobus::SocketCANInterface>("vcan0");
 #elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
 	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
@@ -87,7 +87,7 @@ int main()
 
 	isobus::InternalControlFunction TestInternalECU(TestDeviceNAME, 0x1C, 0);
 
-	isobus::FastPacketProtocol::Protocol.register_multipacket_message_callback(0x1F001, nmea2k_callback, nullptr);
+	isobus::CANNetworkManager::CANNetwork.get_fast_packet_protocol().register_multipacket_message_callback(0x1F001, nmea2k_callback, nullptr);
 
 	// Wait to make sure address claiming is done. The time is arbitrary.
 	//! @todo Check this instead of asuming it is done
@@ -105,13 +105,13 @@ int main()
 	while (running)
 	{
 		// Send a fast packet message
-		isobus::FastPacketProtocol::Protocol.send_multipacket_message(0x1F001, testMessageData, TEST_MESSAGE_LENGTH, &TestInternalECU, nullptr, isobus::CANIdentifier::PriorityLowest7, nmea2k_transmit_complete_callback);
+		isobus::CANNetworkManager::CANNetwork.get_fast_packet_protocol().send_multipacket_message(0x1F001, testMessageData, TEST_MESSAGE_LENGTH, &TestInternalECU, nullptr, isobus::CANIdentifier::PriorityLowest7, nmea2k_transmit_complete_callback);
 
 		// Sleep for a while
 		std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 	}
 
 	isobus::CANHardwareInterface::stop();
-	isobus::FastPacketProtocol::Protocol.remove_multipacket_message_callback(0x1F001, nmea2k_callback, nullptr);
+	isobus::CANNetworkManager::CANNetwork.get_fast_packet_protocol().remove_multipacket_message_callback(0x1F001, nmea2k_callback, nullptr);
 	return 0;
 }

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -21,6 +21,7 @@
 #include "isobus/isobus/can_internal_control_function.hpp"
 #include "isobus/isobus/can_message.hpp"
 #include "isobus/isobus/can_transport_protocol.hpp"
+#include "isobus/isobus/nmea2000_fast_packet_protocol.hpp"
 
 #include <array>
 #include <deque>
@@ -135,6 +136,8 @@ namespace isobus
 		/// @brief Informs the network manager that a partner was deleted so that it can be purged from the address/cf tables
 		/// @param[in] partner Pointer to the partner being deleted
 		void on_partner_deleted(PartneredControlFunction *partner, CANLibBadge<PartneredControlFunction>);
+
+		FastPacketProtocol &get_fast_packet_protocol();
 
 	protected:
 		// Using protected region to allow protocols use of special functions from the network manager
@@ -292,6 +295,7 @@ namespace isobus
 		static constexpr std::uint32_t BUSLOAD_UPDATE_FREQUENCY_MS = 100; ///< Bus load bit accumulation happens over a 100ms window
 
 		ExtendedTransportProtocolManager extendedTransportProtocol; ///< Static instance of the protocol manager
+		FastPacketProtocol fastPacketProtocol; ///< Instance of the fast packet protocol
 		TransportProtocolManager transportProtocol; ///< Static instance of the transport protocol manager
 
 		std::array<std::deque<std::uint32_t>, CAN_PORT_MAXIMUM> busloadMessageBitsHistory; ///< Stores the approximate number of bits processed on each channel over multiple previous time windows

--- a/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
+++ b/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
@@ -38,8 +38,6 @@ namespace isobus
 	class FastPacketProtocol : public CANLibProtocol
 	{
 	public:
-		static FastPacketProtocol Protocol; ///< Static instance of the protocol
-
 		/// @brief A generic way to initialize a protocol
 		/// @details The network manager will call a protocol's initialize function
 		/// when it is first updated, if it has yet to be initialized.

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -358,6 +358,11 @@ namespace isobus
 		}
 	}
 
+	FastPacketProtocol &CANNetworkManager::get_fast_packet_protocol()
+	{
+		return fastPacketProtocol;
+	}
+
 	bool CANNetworkManager::add_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer)
 	{
 		bool retVal = false;

--- a/isobus/src/nmea2000_fast_packet_protocol.cpp
+++ b/isobus/src/nmea2000_fast_packet_protocol.cpp
@@ -19,12 +19,11 @@
 
 namespace isobus
 {
-	FastPacketProtocol FastPacketProtocol::Protocol;
-
 	FastPacketProtocol::FastPacketProtocolSession::FastPacketProtocolSession(Direction sessionDirection, std::uint8_t canPortIndex) :
 	  sessionMessage(canPortIndex),
 	  sessionCompleteCallback(nullptr),
 	  frameChunkCallback(nullptr),
+	  parent(nullptr),
 	  timestamp_ms(0),
 	  lastPacketNumber(0),
 	  packetCount(0),


### PR DESCRIPTION
* Moved the fast packet protocol instance into the network manager to prevent it from getting optimized out when linking as a static library. 
* Added a getter to the network manager to get the protocol instance. 
* Fixed one session variable not being initialized at construction (though this probably was not causing issues). 
* Updated the FP example to use the new protocol instance.

Closes #245 