### PR TITLE
[HW]: Make MCP2515 plugin transmitting and receiving reliable

### DIFF
--- a/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
@@ -173,6 +173,8 @@ namespace isobus
 
 		SPIHardwarePlugin *transactionHandler; ///< The SPI transaction handler
 		std::uint8_t rxIndex = 0; ///< The index of the rx buffer to read from next
+		std::uint8_t txIndex = 2; ///< The index of the tx buffer to write to next, start with 2 as it is the buffer with the highest priority
+		std::uint8_t txPriority = 3; ///< The priority of the next tx frame
 		const std::uint8_t cfg1; ///< Configuration value for CFG1 register
 		const std::uint8_t cfg2; ///< Configuration value for CFG2 register
 		const std::uint8_t cfg3; ///< Configuration value for CFG3 register

--- a/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
@@ -172,10 +172,11 @@ namespace isobus
 		bool write_frame(const isobus::HardwareInterfaceCANFrame &canFrame, const MCPRegister ctrlRegister, const MCPRegister sidhRegister);
 
 		SPIHardwarePlugin *transactionHandler; ///< The SPI transaction handler
+		std::uint8_t rxIndex = 0; ///< The index of the rx buffer to read from next
 		const std::uint8_t cfg1; ///< Configuration value for CFG1 register
 		const std::uint8_t cfg2; ///< Configuration value for CFG2 register
 		const std::uint8_t cfg3; ///< Configuration value for CFG3 register
-		bool initialized; ///< If the mcp2515 has been initialized and no errors have occured
+		bool initialized = false; ///< If the mcp2515 has been initialized and no errors have occurred
 	};
 }
 #endif // MCP2515_CAN_INTERFACE_HPP

--- a/hardware_integration/src/twai_plugin.cpp
+++ b/hardware_integration/src/twai_plugin.cpp
@@ -82,7 +82,7 @@ namespace isobus
 
 		//Wait for message to be received
 		twai_message_t message = {};
-		esp_err_t error = twai_receive(&message, pdMS_TO_TICKS(1000));
+		esp_err_t error = twai_receive(&message, pdMS_TO_TICKS(100));
 		if (ESP_OK == error)
 		{
 			// Process received message
@@ -117,7 +117,7 @@ namespace isobus
 		message.data_length_code = canFrame.dataLength;
 		memcpy(message.data, canFrame.data, canFrame.dataLength);
 
-		esp_err_t error = twai_transmit(&message, portMAX_DELAY);
+		esp_err_t error = twai_transmit(&message, pdMS_TO_TICKS(100));
 		if (ESP_OK == error)
 		{
 			retVal = true;


### PR DESCRIPTION
Previously the MCP2515 plugin wasn't always transmitting or receiving CAN messages in the correct order, this should be fixed in the PR. The changes made to achieve this:
- Use an cached index for reading the correct buffer when messages 'rollover'
- Log to the user when a frame failed to transmit, this is done when sending the next message to preserve communication speed
- Only use **one** of the three available buffers for transmitting. I'm not sure how to implement multiple transmitting buffers while keeping the messages transmitted in the correct order. Any ideas are welcome!

Also changed the timeout for transmitting/receiving messages with the TWAI plugin to 100ms. This might be useful for example when no CANbus is connected.