### PR TITLE
[VT]: Fixed a missing const

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -725,7 +725,7 @@ namespace isobus
 		/// @param[in] attributeID The attribute ID of the attribute being changed
 		/// @param[in] value The new attribute value
 		/// @returns true if the message was sent successfully
-		bool send_change_attribute(std::uint16_t objectID, std::uint8_t attributeID, float value);
+		bool send_change_attribute(std::uint16_t objectID, std::uint8_t attributeID, float value) const;
 
 		/// @brief Sends the change priority command
 		/// @details This command is used to change the priority of an Alarm Mask.

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -610,7 +610,7 @@ namespace isobus
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
-	bool VirtualTerminalClient::send_change_attribute(std::uint16_t objectID, std::uint8_t attributeID, float value)
+	bool VirtualTerminalClient::send_change_attribute(std::uint16_t objectID, std::uint8_t attributeID, float value) const
 	{
 		static_assert(sizeof(float) == 4, "Float must be 4 bytes");
 		std::array<std::uint8_t, sizeof(float)> floatBytes = { 0 };


### PR DESCRIPTION
* Fixed a missing `const` causing some ambiguity when calling send_change_attribute