### PR TITLE
[Core]: Add internal CF filtering option for partner CF callbacks

### DIFF
--- a/isobus/include/isobus/isobus/can_callbacks.hpp
+++ b/isobus/include/isobus/isobus/can_callbacks.hpp
@@ -66,7 +66,8 @@ namespace isobus
 		/// @param[in] parameterGroupNumber The PGN you want to register a callback for
 		/// @param[in] callback The function you want the stack to call when it gets receives a message with a matching PGN
 		/// @param[in] parentPointer A generic variable that can provide context to which object the callback was meant for
-		ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer);
+		/// @param[in] internalControlFunction An internal control function to use as an additional filter for the callback
+		ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, InternalControlFunction *internalControlFunction);
 
 		/// @brief A copy constructor for holding callback data
 		/// @param[in] oldObj The object to copy from
@@ -93,10 +94,15 @@ namespace isobus
 		/// @brief Returns the parent pointer for this data object
 		void *get_parent() const;
 
+		/// @brief Returns the ICF being used as a filter for this callback
+		/// @returns A pointer to the ICF being used as a filter, or nullptr
+		InternalControlFunction *get_internal_control_function() const;
+
 	private:
 		CANLibCallback mCallback; ///< The callback that will get called when a matching PGN is received
 		std::uint32_t mParameterGroupNumber; ///< The PGN assocuiated with this callback
 		void *mParent; ///< A generic variable that can provide context to which object the callback was meant for
+		InternalControlFunction *mInternalControlFunctionFilter; ///< An optional way to filter callbacks based on the destination of messages from the partner
 	};
 } // namespace isobus
 

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -137,6 +137,9 @@ namespace isobus
 		/// @param[in] partner Pointer to the partner being deleted
 		void on_partner_deleted(PartneredControlFunction *partner, CANLibBadge<PartneredControlFunction>);
 
+		/// @brief Returns the class instance of the NMEA2k fast packet protocol.
+		/// Use this to register for FP multipacket messages
+		/// @returns The class instance of the NMEA2k fast packet protocol.
 		FastPacketProtocol &get_fast_packet_protocol();
 
 	protected:

--- a/isobus/include/isobus/isobus/can_partnered_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_partnered_control_function.hpp
@@ -22,6 +22,7 @@
 namespace isobus
 {
 	class CANNetworkManager;
+	class InternalControlFunction;
 
 	//================================================================================================
 	/// @class PartneredControlFunction
@@ -57,13 +58,17 @@ namespace isobus
 		/// @param[in] parameterGroupNumber The PGN you want to use to communicate, or `CANLibParameterGroupNumber::Any`
 		/// @param[in] callback The function you want to get called when a message is received with parameterGroupNumber from this CF
 		/// @param[in] parent A generic context variable that helps identify what object the callback was destined for
-		void add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] internalControlFunction An internal control function to filter based on. If you supply this
+		/// parameter the callback will only be called when messages from the partner are received with the
+		/// specified ICF as the destination.
+		void add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction = nullptr);
 
 		/// @brief Removes a callback matching *exactly* the parameters passed in
 		/// @param[in] parameterGroupNumber The PGN associated with the callback being removed
 		/// @param[in] callback The callback function being removed
 		/// @param[in] parent A generic context variable that helps identify what object the callback was destined for
-		void remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] internalControlFunction The ICF being used to filter messages against
+		void remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction = nullptr);
 
 		/// @brief Returns the number of parameter group number callbacks associated with this control function
 		/// @returns The number of parameter group number callbacks associated with this control function

--- a/isobus/include/isobus/isobus/isobus_functionalities.hpp
+++ b/isobus/include/isobus/isobus/isobus_functionalities.hpp
@@ -422,7 +422,7 @@ namespace isobus
 
 		/// @brief Checks for the existence of a functionality in the list of previously configured functionalities
 		/// and returns an iterator to that functionality in the list
-		/// @param[in] functionalityToRetreive The functionality to return
+		/// @param[in] functionalityToRetrieve The functionality to return
 		/// @returns Iterator to the desired functionality, or supportedFunctionalities.end() if not found
 		std::list<FunctionalityData>::iterator get_functionality(Functionalities functionalityToRetrieve);
 

--- a/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
+++ b/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
@@ -47,13 +47,16 @@ namespace isobus
 		/// @param[in] parameterGroupNumber The PGN to parse as fast packet
 		/// @param[in] callback The callback that the stack will call when a matching message is received
 		/// @param[in] parent Generic context variable
-		void register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] internalControlFunction An internal control function to use as an additional filter for the callback.
+		/// Only messages destined for the specified ICF will generate a callback. Use nullptr to receive all messages.
+		void register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction = nullptr);
 
 		// @brief Removes a callback previously added with register_multipacket_message_callback
 		/// @param[in] parameterGroupNumber The PGN to parse as fast packet
 		/// @param[in] callback The callback that the stack will call when a matching message is received
 		/// @param[in] parent Generic context variable
-		void remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent);
+		/// @param[in] internalControlFunction An internal control function to use as an additional filter for the callback
+		void remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction = nullptr);
 
 		/// @brief Used to send CAN messages using fast packet
 		/// @details You have to use this function instead of the network manager

--- a/isobus/src/can_callbacks.cpp
+++ b/isobus/src/can_callbacks.cpp
@@ -10,25 +10,28 @@
 
 namespace isobus
 {
-	ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer) :
+	ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, InternalControlFunction *internalControlFunction) :
 	  mCallback(callback),
 	  mParameterGroupNumber(parameterGroupNumber),
-	  mParent(parentPointer)
+	  mParent(parentPointer),
+	  mInternalControlFunctionFilter(internalControlFunction)
 	{
 	}
 
-	ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(const ParameterGroupNumberCallbackData &oldObj)
+	ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(const ParameterGroupNumberCallbackData &oldObj) :
+	  mCallback(oldObj.mCallback),
+	  mParameterGroupNumber(oldObj.mParameterGroupNumber),
+	  mParent(oldObj.mParent),
+	  mInternalControlFunctionFilter(oldObj.mInternalControlFunctionFilter)
 	{
-		mCallback = oldObj.mCallback;
-		mParameterGroupNumber = oldObj.mParameterGroupNumber;
-		mParent = oldObj.mParent;
 	}
 
 	bool ParameterGroupNumberCallbackData::operator==(const ParameterGroupNumberCallbackData &obj) const
 	{
 		return ((obj.mCallback == this->mCallback) &&
 		        (obj.mParameterGroupNumber == this->mParameterGroupNumber) &&
-		        (obj.mParent == this->mParent));
+		        (obj.mParent == this->mParent) &&
+		        (obj.mInternalControlFunctionFilter == this->mInternalControlFunctionFilter));
 	}
 
 	ParameterGroupNumberCallbackData &ParameterGroupNumberCallbackData::operator=(const ParameterGroupNumberCallbackData &obj)
@@ -36,6 +39,7 @@ namespace isobus
 		mCallback = obj.mCallback;
 		mParameterGroupNumber = obj.mParameterGroupNumber;
 		mParent = obj.mParent;
+		mInternalControlFunctionFilter = obj.mInternalControlFunctionFilter;
 		return *this;
 	}
 
@@ -52,5 +56,10 @@ namespace isobus
 	void *ParameterGroupNumberCallbackData::get_parent() const
 	{
 		return mParent;
+	}
+
+	InternalControlFunction *ParameterGroupNumberCallbackData::get_internal_control_function() const
+	{
+		return mInternalControlFunctionFilter;
 	}
 } // namespace isobus

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -51,12 +51,12 @@ namespace isobus
 
 	void CANNetworkManager::add_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
-		globalParameterGroupNumberCallbacks.emplace_back(parameterGroupNumber, callback, parent);
+		globalParameterGroupNumberCallbacks.emplace_back(parameterGroupNumber, callback, parent, nullptr);
 	}
 
 	void CANNetworkManager::remove_global_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
-		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent);
+		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent, nullptr);
 		auto callbackLocation = std::find(globalParameterGroupNumberCallbacks.begin(), globalParameterGroupNumberCallbacks.end(), tempObject);
 		if (globalParameterGroupNumberCallbacks.end() != callbackLocation)
 		{
@@ -72,12 +72,12 @@ namespace isobus
 	void CANNetworkManager::add_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
 		std::lock_guard<std::mutex> lock(anyControlFunctionCallbacksMutex);
-		anyControlFunctionParameterGroupNumberCallbacks.emplace_back(parameterGroupNumber, callback, parent);
+		anyControlFunctionParameterGroupNumberCallbacks.emplace_back(parameterGroupNumber, callback, parent, nullptr);
 	}
 
 	void CANNetworkManager::remove_any_control_function_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
 	{
-		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent);
+		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent, nullptr);
 		std::lock_guard<std::mutex> lock(anyControlFunctionCallbacksMutex);
 		auto callbackLocation = std::find(anyControlFunctionParameterGroupNumberCallbacks.begin(), anyControlFunctionParameterGroupNumberCallbacks.end(), tempObject);
 		if (anyControlFunctionParameterGroupNumberCallbacks.end() != callbackLocation)
@@ -259,7 +259,7 @@ namespace isobus
 
 	ParameterGroupNumberCallbackData CANNetworkManager::get_global_parameter_group_number_callback(std::uint32_t index) const
 	{
-		ParameterGroupNumberCallbackData retVal(0, nullptr, nullptr);
+		ParameterGroupNumberCallbackData retVal(0, nullptr, nullptr, nullptr);
 
 		if (index < get_number_global_parameter_group_number_callbacks())
 		{
@@ -366,7 +366,7 @@ namespace isobus
 	bool CANNetworkManager::add_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer)
 	{
 		bool retVal = false;
-		ParameterGroupNumberCallbackData callbackInfo(parameterGroupNumber, callback, parentPointer);
+		ParameterGroupNumberCallbackData callbackInfo(parameterGroupNumber, callback, parentPointer, nullptr);
 
 		const std::lock_guard<std::mutex> lock(protocolPGNCallbacksMutex);
 
@@ -381,7 +381,7 @@ namespace isobus
 	bool CANNetworkManager::remove_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer)
 	{
 		bool retVal = false;
-		ParameterGroupNumberCallbackData callbackInfo(parameterGroupNumber, callback, parentPointer);
+		ParameterGroupNumberCallbackData callbackInfo(parameterGroupNumber, callback, parentPointer, nullptr);
 
 		const std::lock_guard<std::mutex> lock(protocolPGNCallbacksMutex);
 
@@ -796,7 +796,9 @@ namespace isobus
 								for (std::size_t k = 0; k < currentControlFunction->get_number_parameter_group_number_callbacks(); k++)
 								{
 									if ((message->get_identifier().get_parameter_group_number() == currentControlFunction->get_parameter_group_number_callback(k).get_parameter_group_number()) &&
-									    (nullptr != currentControlFunction->get_parameter_group_number_callback(k).get_callback()))
+									    (nullptr != currentControlFunction->get_parameter_group_number_callback(k).get_callback()) &&
+									    ((nullptr == currentControlFunction->get_parameter_group_number_callback(k).get_internal_control_function()) ||
+									     (currentControlFunction->get_parameter_group_number_callback(k).get_internal_control_function()->get_address() == message->get_identifier().get_destination_address())))
 									{
 										// We have a callback matching this message
 										currentControlFunction->get_parameter_group_number_callback(k).get_callback()(message, currentControlFunction->get_parameter_group_number_callback(k).get_parent());

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -61,14 +61,14 @@ namespace isobus
 		}
 	}
 
-	void PartneredControlFunction::add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
+	void PartneredControlFunction::add_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction)
 	{
-		parameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent));
+		parameterGroupNumberCallbacks.emplace_back(parameterGroupNumber, callback, parent, internalControlFunction);
 	}
 
-	void PartneredControlFunction::remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
+	void PartneredControlFunction::remove_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction)
 	{
-		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent);
+		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent, internalControlFunction);
 		auto callbackLocation = std::find(parameterGroupNumberCallbacks.begin(), parameterGroupNumberCallbacks.end(), tempObject);
 		if (parameterGroupNumberCallbacks.end() != callbackLocation)
 		{

--- a/isobus/src/nmea2000_fast_packet_protocol.cpp
+++ b/isobus/src/nmea2000_fast_packet_protocol.cpp
@@ -52,15 +52,15 @@ namespace isobus
 		}
 	}
 
-	void FastPacketProtocol::register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
+	void FastPacketProtocol::register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction)
 	{
-		parameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent));
+		parameterGroupNumberCallbacks.push_back(ParameterGroupNumberCallbackData(parameterGroupNumber, callback, parent, internalControlFunction));
 		CANNetworkManager::CANNetwork.add_protocol_parameter_group_number_callback(parameterGroupNumber, process_message, this);
 	}
 
-	void FastPacketProtocol::remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent)
+	void FastPacketProtocol::remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction)
 	{
-		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent);
+		ParameterGroupNumberCallbackData tempObject(parameterGroupNumber, callback, parent, internalControlFunction);
 		auto callbackLocation = std::find(parameterGroupNumberCallbacks.begin(), parameterGroupNumberCallbacks.end(), tempObject);
 		if (parameterGroupNumberCallbacks.end() != callbackLocation)
 		{
@@ -245,7 +245,9 @@ namespace isobus
 
 				for (auto &callback : parameterGroupNumberCallbacks)
 				{
-					if (callback.get_parameter_group_number() == message->get_identifier().get_parameter_group_number())
+					if ((callback.get_parameter_group_number() == message->get_identifier().get_parameter_group_number()) &&
+					    ((nullptr == callback.get_internal_control_function()) ||
+					     (callback.get_internal_control_function()->get_address() == message->get_destination_control_function()->get_address())))
 					{
 						pgnNeedsParsing = true;
 						break;


### PR DESCRIPTION
This allows users to register callbacks for messages from a partner that are filtered by destination internal control function.

This essentially helps you only get callbacks for messages destined for one specific ICF if you have multiple, making a multi-ECU application easier/nicer.

Closes #206.