### PR TITLE
Add ISOBUS Guidance (Steering) Interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ if(BUILD_EXAMPLES)
   add_subdirectory("examples/virtual_terminal/aux_functions")
   add_subdirectory("examples/virtual_terminal/aux_inputs")
   add_subdirectory("examples/task_controller_client")
+  add_subdirectory("examples/guidance")
 endif()
 
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,8 @@ if(BUILD_TESTING)
       test/ddop_tests.cpp
       test/event_dispatcher_tests.cpp
       test/isb_tests.cpp
-      test/cf_functionalities_tests.cpp)
+      test/cf_functionalities_tests.cpp
+      test/guidance_tests.cpp)
 
   add_executable(unit_tests ${TEST_SRC})
   target_link_libraries(

--- a/examples/guidance/CMakeLists.txt
+++ b/examples/guidance/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.16)
+project(guidance_example)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT BUILD_EXAMPLES)
+  find_package(isobus REQUIRED)
+endif()
+find_package(Threads REQUIRED)
+
+add_executable(GuidanceExampleTarget main.cpp console_logger.cpp)
+target_link_libraries(
+  GuidanceExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration
+                                isobus::Utility)

--- a/examples/guidance/console_logger.cpp
+++ b/examples/guidance/console_logger.cpp
@@ -1,0 +1,67 @@
+#include "isobus/isobus/can_stack_logger.hpp"
+
+#include <iostream>
+
+// A log sink for the CAN stack
+class CustomLogger : public isobus::CANStackLogger
+{
+public:
+	void sink_CAN_stack_log(CANStackLogger::LoggingLevel level, const std::string &text) override
+	{
+		switch (level)
+		{
+			case LoggingLevel::Debug:
+			{
+				std::cout << "["
+				          << "\033[1;36m"
+				          << "Debug"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Info:
+			{
+				std::cout << "["
+				          << "\033[1;32m"
+				          << "Info"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Warning:
+			{
+				std::cout << "["
+				          << "\033[1;33m"
+				          << "Warn"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Error:
+			{
+				std::cout << "["
+				          << "\033[1;31m"
+				          << "Error"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+
+			case LoggingLevel::Critical:
+			{
+				std::cout << "["
+				          << "\033[1;35m"
+				          << "Critical"
+				          << "\033[0m"
+				          << "]";
+			}
+			break;
+		}
+		std::cout << text << std::endl; // Write the text to stdout
+	}
+};
+
+static CustomLogger logger;

--- a/examples/guidance/main.cpp
+++ b/examples/guidance/main.cpp
@@ -1,0 +1,123 @@
+#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "isobus/hardware_integration/can_hardware_interface.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
+#include "isobus/isobus/isobus_guidance_interface.hpp"
+
+#include "console_logger.cpp"
+
+#include <atomic>
+#include <csignal>
+#include <functional>
+#include <iostream>
+#include <memory>
+
+//! It is discouraged to use global variables, but it is done here for simplicity.
+static std::atomic_bool running = { true };
+static bool is_first_machine_info_message = true;
+static bool is_first_system_command_message = true;
+
+void signal_handler(int)
+{
+	running = false;
+}
+
+void on_guidance_machine_info_message(const std::shared_ptr<isobus::AgriculturalGuidanceInterface::GuidanceMachineInfo> info, bool changed)
+{
+	//! @note changed is true when the info has changed since the last time,
+	//!       this means that your initial message callback might not be flagged as changed.
+	if (changed || is_first_machine_info_message)
+	{
+		is_first_machine_info_message = false;
+		std::cout << "Agriculture Guidance Machine Info: " << std::endl;
+		std::cout << "  Estimated curvature: " << info->get_estimated_curvature() << std::endl;
+		std::cout << "  Limit status: " << static_cast<int>(info->get_guidance_limit_status()) << std::endl;
+		std::cout << "  Steering-input position status: " << static_cast<int>(info->get_guidance_steering_input_position_status()) << std::endl;
+		std::cout << "  Steering-system readiness state: " << static_cast<int>(info->get_guidance_steering_system_readiness_state()) << std::endl;
+		std::cout << "  Steering-system command exit reason code: " << static_cast<int>(info->get_guidance_system_command_exit_reason_code()) << std::endl;
+		std::cout << "  Steering-system remote engage switch status: " << static_cast<int>(info->get_guidance_system_remote_engage_switch_status()) << std::endl;
+		std::cout << "  Mechanical system lockout: " << static_cast<int>(info->get_mechanical_system_lockout()) << std::endl;
+		std::cout << "  Request reset command status: " << static_cast<int>(info->get_request_reset_command_status()) << std::endl;
+	}
+}
+
+void on_guidance_system_command_message(const std::shared_ptr<isobus::AgriculturalGuidanceInterface::GuidanceSystemCommand> status, bool changed)
+{
+	//! @note changed is true when the info has changed since the last time,
+	//!       this means that your initial message callback might not be flagged as changed.
+	if (changed || is_first_system_command_message)
+	{
+		is_first_system_command_message = false;
+		std::cout << "Agriculture Guidance System Command: " << std::endl;
+		std::cout << "  Curvature: " << status->get_curvature() << std::endl;
+		std::cout << "  Status: " << static_cast<int>(status->get_status()) << std::endl;
+	}
+}
+
+int main()
+{
+	std::signal(SIGINT, signal_handler);
+
+	// Automatically load the desired CAN driver based on the available drivers
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
+#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
+	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
+#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
+#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
+#endif
+	if (nullptr == canDriver)
+	{
+		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;
+		std::cout << "If you want to use a different driver, please add it to the list above." << std::endl;
+		return -1;
+	}
+
+	isobus::CANStackLogger::set_can_stack_logger_sink(&logger);
+	isobus::CANStackLogger::set_log_level(isobus::CANStackLogger::LoggingLevel::Info); // Change this to Debug to see more information
+	isobus::CANHardwareInterface::set_number_of_can_channels(1);
+	isobus::CANHardwareInterface::assign_can_channel_frame_handler(0, canDriver);
+
+	if ((!isobus::CANHardwareInterface::start()) || (!canDriver->get_is_valid()))
+	{
+		std::cout << "Failed to start hardware interface. The CAN driver might be invalid." << std::endl;
+		return -2;
+	}
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+	isobus::NAME TestDeviceNAME(0);
+
+	//! Make sure you change these for your device!!!!
+	//! This is an example device that is using a manufacturer code that is currently unused at time of writing
+	TestDeviceNAME.set_arbitrary_address_capable(true);
+	TestDeviceNAME.set_industry_group(1);
+	TestDeviceNAME.set_device_class(0);
+	TestDeviceNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::SteeringControl));
+	TestDeviceNAME.set_identity_number(3);
+	TestDeviceNAME.set_ecu_instance(0);
+	TestDeviceNAME.set_function_instance(0);
+	TestDeviceNAME.set_device_class_instance(0);
+	TestDeviceNAME.set_manufacturer_code(64);
+
+	isobus::AgriculturalGuidanceInterface TestGuidanceInterface(nullptr, nullptr);
+
+	// Register listeners for the (guidance) events we want to receive
+	//! @note That the listeners are removed automatically when the returned `shared_ptr` goes out of scope!!!
+	auto guidanceMachineInfoListener = TestGuidanceInterface.get_guidance_machine_info_event_publisher().add_listener(on_guidance_machine_info_message);
+	auto guidanceSystemCommandListener = TestGuidanceInterface.get_guidance_system_command_event_publisher().add_listener(on_guidance_system_command_message);
+
+	// Finally we can initialize the guidance interface to start sending and receiving messages
+	TestGuidanceInterface.initialize();
+
+	while (running)
+	{
+		TestGuidanceInterface.update();
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+
+	isobus::CANHardwareInterface::stop();
+	return 0;
+}

--- a/hardware_integration/src/virtual_can_plugin.cpp
+++ b/hardware_integration/src/virtual_can_plugin.cpp
@@ -79,7 +79,7 @@ namespace isobus
 	bool VirtualCANPlugin::read_frame(isobus::HardwareInterfaceCANFrame &canFrame)
 	{
 		std::unique_lock<std::mutex> lock(mutex);
-		ourDevice->condition.wait(lock, [this] { return !running || !ourDevice->queue.empty(); });
+		ourDevice->condition.wait_for(lock, std::chrono::milliseconds(1000), [this] { return !ourDevice->queue.empty() || !running; });
 		if (!ourDevice->queue.empty())
 		{
 			canFrame = ourDevice->queue.front();

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -38,7 +38,8 @@ set(ISOBUS_SRC
     "isobus_task_controller_client.cpp"
     "isobus_device_descriptor_object_pool.cpp"
     "isobus_shortcut_button_interface.cpp"
-    "isobus_functionalities.cpp")
+    "isobus_functionalities.cpp"
+    "isobus_guidance_interface.cpp")
 
 # Prepend the source directory path to all the source files
 prepend(ISOBUS_SRC ${ISOBUS_SRC_DIR} ${ISOBUS_SRC})
@@ -77,9 +78,7 @@ set(ISOBUS_INCLUDE
     "isobus_device_descriptor_object_pool.hpp"
     "isobus_shortcut_button_interface.hpp"
     "isobus_functionalities.hpp")
-
 # Prepend the include directory path to all the include files
-prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})
 
 # Create the library from the source and include files
 add_library(Isobus ${ISOBUS_SRC} ${ISOBUS_INCLUDE})

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -79,6 +79,7 @@ set(ISOBUS_INCLUDE
     "isobus_shortcut_button_interface.hpp"
     "isobus_functionalities.hpp")
 # Prepend the include directory path to all the include files
+prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})
 
 # Create the library from the source and include files
 add_library(Isobus ${ISOBUS_SRC} ${ISOBUS_INCLUDE})

--- a/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
+++ b/isobus/include/isobus/isobus/can_general_parameter_group_numbers.hpp
@@ -16,6 +16,8 @@ namespace isobus
 	enum class CANLibParameterGroupNumber
 	{
 		Any = 0x0000,
+		AgriculturalGuidanceMachineInfo = 0xAC00,
+		AgriculturalGuidanceSystemCommand = 0xAD00,
 		DiagnosticMessage22 = 0xC300,
 		ExtendedTransportProtocolDataTransfer = 0xC700,
 		ExtendedTransportProtocolConnectionManagement = 0xC800,

--- a/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
@@ -32,16 +32,16 @@
 namespace isobus
 {
 	/// @brief An interface for sending and receiving ISOBUS guidance messages
-	class GuidanceInterface
+	class AgriculturalGuidanceInterface
 	{
 	public:
-		/// @brief Constructor for a GuidanceInterface
+		/// @brief Constructor for a AgriculturalGuidanceInterface
 		/// @param[in] source The internal control function to use when sending messages, or nullptr for listen only
 		/// @param[in] destination The destination control function for transmitted messages, or nullptr for broadcasts
-		GuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
+		AgriculturalGuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
-		/// @brief Destructor for the GuidanceInterface
-		~GuidanceInterface();
+		/// @brief Destructor for the AgriculturalGuidanceInterface
+		~AgriculturalGuidanceInterface();
 
 		/// @brief An interface for sending the agricultural
 		/// guidance system command message.
@@ -68,10 +68,11 @@ namespace isobus
 			/// the CAN message. This parameter indicates whether the guidance system is
 			/// attempting to control steering with this command
 			/// @param[in] newStatus The status to encode into the message
-			void set_status(CurvatureCommandStatus newStatus);
+			/// @returns True if the status changed, false otherwise
+			bool set_status(CurvatureCommandStatus newStatus);
 
-			/// @brief Returns the curvature command status that was set with set_status
-			/// @returns The curvature command status that was set with set_status
+			/// @brief Returns the curvature command status that is active in the guidance system
+			/// @returns The curvature command status
 			CurvatureCommandStatus get_status() const;
 
 			/// @brief Desired course curvature over ground that a machine's
@@ -84,9 +85,10 @@ namespace isobus
 			/// Curvature is positive when the vehicle is moving forward and turning to the driver's right
 			///
 			/// @param[in] curvature Commanded curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
-			void set_curvature(float curvature);
+			/// @returns True if the curvature changed, false otherwise
+			bool set_curvature(float curvature);
 
-			/// @brief Returns the curvature command that was set with set_curvature
+			/// @brief Returns the curvature value that is currently be trying to be achieved by the guidance system
 			/// @returns Commanded curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
 			float get_curvature() const;
 
@@ -119,7 +121,7 @@ namespace isobus
 		};
 
 		/// @brief An interface for sending and receiving the ISOBUS agricultural guidance machine message
-		class AgriculturalGuidanceMachineInfo
+		class GuidanceMachineInfo
 		{
 		public:
 			/// @brief State of a lockout switch that allows operators to
@@ -143,7 +145,7 @@ namespace isobus
 				NotAvailable = 3
 			};
 
-			/// @brief A typical, generic 2 bit value in J1939 with no supersceding definition in ISO 11783
+			/// @brief A typical, generic 2 bit value in J1939 with no superseding definition in ISO 11783
 			enum class GenericSAEbs02SlotValue : std::uint8_t
 			{
 				DisabledOffPassive = 0,
@@ -191,12 +193,13 @@ namespace isobus
 				NotAvailable = 63 ///< Parameter not supported
 			};
 
-			/// @brief Constructor for a AgriculturalGuidanceMachineInfo
-			AgriculturalGuidanceMachineInfo() = default;
+			/// @brief Constructor for a GuidanceMachineInfo
+			GuidanceMachineInfo() = default;
 
 			/// @brief Sets the estimated course curvature over ground for the machine.
 			/// @param[in] curvature The curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
-			void set_estimated_curvature(float curvature);
+			/// @returns True if the curvature changed, false otherwise
+			bool set_estimated_curvature(float curvature);
 
 			/// @brief Returns the estimated curvature that was previously set with set_estimated_curvature
 			/// @returns The estimated curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
@@ -204,7 +207,8 @@ namespace isobus
 
 			/// @brief Sets the mechanical system lockout state
 			/// @param[in] state The mechanical system lockout state to report
-			void set_mechanical_system_lockout_state(MechanicalSystemLockout state);
+			/// @returns True if the mechanical system lockout state changed, false otherwise
+			bool set_mechanical_system_lockout_state(MechanicalSystemLockout state);
 
 			/// @brief Returns the mechanical system lockout state
 			/// @returns The mechanical system lockout state being reported
@@ -212,7 +216,8 @@ namespace isobus
 
 			/// @brief Sets the guidance system's readiness state to report
 			/// @param[in] state The state to report. See definition of GenericSAEbs02SlotValue
-			void set_guidance_steering_system_readiness_state(GenericSAEbs02SlotValue state);
+			/// @returns True if the guidance steering system readiness state changed, false otherwise
+			bool set_guidance_steering_system_readiness_state(GenericSAEbs02SlotValue state);
 
 			/// @brief Returns the guidance system's readiness state for steering
 			/// @returns The guidance system's readiness state for steering
@@ -220,7 +225,8 @@ namespace isobus
 
 			/// @brief Sets the guidance steering input position state
 			/// @param[in] state The state to set for the guidance steering input position
-			void set_guidance_steering_input_position_status(GenericSAEbs02SlotValue state);
+			/// @returns True if the guidance steering input position status changed, false otherwise
+			bool set_guidance_steering_input_position_status(GenericSAEbs02SlotValue state);
 
 			/// @brief Returns the guidance steering input position state
 			/// @returns Guidance steering input position state
@@ -230,7 +236,8 @@ namespace isobus
 			/// @details Machine steering system request to the automatic guidance system to
 			/// change Curvature Command Status state from "Intended to steer" to "Not intended to steer".
 			/// @param[in] state The request reset command state to report
-			void set_request_reset_command_status(RequestResetCommandStatus state);
+			/// @returns True if the request reset command status changed, false otherwise
+			bool set_request_reset_command_status(RequestResetCommandStatus state);
 
 			/// @brief Returns the reported request reset command
 			/// @details Machine steering system request to the automatic guidance system to
@@ -243,7 +250,8 @@ namespace isobus
 			/// limit status associated with guidance commands that are persistent
 			/// (i.e. not transient/temporary/one-shot).
 			/// @param[in] status The limit status to report
-			void set_guidance_limit_status(GuidanceLimitStatus status);
+			/// @returns True if the guidance limit status changed, false otherwise
+			bool set_guidance_limit_status(GuidanceLimitStatus status);
 
 			/// @brief Returns the reported guidance limit status
 			/// @details This parameter is used to report the steering system's present
@@ -256,7 +264,7 @@ namespace isobus
 			/// @details This parameter is used to indicate why the guidance system cannot currently accept
 			/// remote commands or has most recently stopped accepting remote commands.
 			/// @returns The exit code for the guidance system
-			void set_guidance_system_command_exit_reason_code(std::uint8_t exitCode);
+			bool set_guidance_system_command_exit_reason_code(std::uint8_t exitCode);
 
 			/// @brief Returns the exit code for the guidance system
 			/// @details This parameter is used to indicate why the guidance system cannot currently accept
@@ -266,7 +274,8 @@ namespace isobus
 
 			/// @brief Sets the state for the steering engage switch
 			/// @param[in] switchStatus The engage switch state to report
-			void set_guidance_system_remote_engage_switch_status(GenericSAEbs02SlotValue switchStatus);
+			/// @returns True if the engage switch state changed, false otherwise
+			bool set_guidance_system_remote_engage_switch_status(GenericSAEbs02SlotValue switchStatus);
 
 			/// @brief Returns the state for the steering engage switch
 			/// @returns The state for the steering engage switch
@@ -306,8 +315,8 @@ namespace isobus
 			std::uint8_t guidanceSystemCommandExitReasonCode = static_cast<std::uint8_t>(GuidanceSystemCommandExitReasonCode::NotAvailable); ///< The exit code for guidance, stored as a u8 to preserve manufacturer specific values (SPN 5725)
 		};
 
-		/// @brief Sets up the class and registers it to recieve callbacks from the network manager for processing
-		/// guidance messages. The class will not recieve messages if this is not called.
+		/// @brief Sets up the class and registers it to receive callbacks from the network manager for processing
+		/// guidance messages. The class will not receive messages if this is not called.
 		void initialize();
 
 		/// @brief Returns if the interface has been initialized
@@ -316,7 +325,7 @@ namespace isobus
 
 		/// @brief Use this to configure the transmission of the guidance machine info message from your application. If you pass in an internal control function
 		/// to the constructor of this class, then this message is available to be sent.
-		AgriculturalGuidanceMachineInfo agriculturalGuidanceMachineInfoTransmitData;
+		GuidanceMachineInfo guidanceMachineInfoTransmitData;
 
 		/// @brief Use this to configure transmission the guidance system command message from your application. If you pass in an internal control function
 		/// to the constructor of this class, then this message is available to be sent.
@@ -328,17 +337,17 @@ namespace isobus
 
 		/// @brief Returns the number of received, unique guidance machine info message sources
 		/// @returns The number of CFs sending the guidance machine info message either as a broadcast, or to our internal control function
-		std::size_t get_number_received_agricultural_guidance_machine_info_message_sources() const;
+		std::size_t get_number_received_guidance_machine_info_message_sources() const;
 
 		/// @brief Returns the content of the agricultural guidance machine info message
-		/// based on the index of the sender. Use this to read the recieved messages' content.
+		/// based on the index of the sender. Use this to read the received messages' content.
 		/// @param[in] index An index of senders of the agricultural guidance machine info message
 		/// @note Only one device on the bus will send this normally, but we provide a generic way to get
 		/// an arbitrary number of these commands. So generally using only index 0 will be acceptable.
-		std::shared_ptr<AgriculturalGuidanceMachineInfo> get_received_agricultural_guidance_machine_info(std::size_t index);
+		std::shared_ptr<GuidanceMachineInfo> get_received_guidance_machine_info(std::size_t index);
 
 		/// @brief Returns the content of the agricultural guidance curvature command message
-		/// based on the index of the sender. Use this to read the recieved messages' content.
+		/// based on the index of the sender. Use this to read the received messages' content.
 		/// @param[in] index An index of senders of the agricultural guidance curvature command message
 		/// @note Only one device on the bus will send this normally, but we provide a generic way to get
 		/// an arbitrary number of these commands. So generally using only index 0 will be acceptable.
@@ -346,11 +355,11 @@ namespace isobus
 
 		/// @brief Returns an event dispatcher which you can use to get callbacks when new/updated guidance machine info messages are received.
 		/// @returns The event publisher for guidance machine info messages
-		EventDispatcher<const std::shared_ptr<AgriculturalGuidanceMachineInfo>> &get_agricultural_guidance_machine_info_event_publisher();
+		EventDispatcher<const std::shared_ptr<GuidanceMachineInfo>, bool> &get_guidance_machine_info_event_publisher();
 
 		/// @brief Returns an event dispatcher which you can use to get callbacks when new/updated guidance system command messages are received.
 		/// @returns The event publisher for guidance system command messages
-		EventDispatcher<const std::shared_ptr<GuidanceSystemCommand>> &get_guidance_guidance_system_command_event_publisher();
+		EventDispatcher<const std::shared_ptr<GuidanceSystemCommand>, bool> &get_guidance_system_command_event_publisher();
 
 		/// @brief Call this cyclically to update the interface. Transmits messages if needed and processes
 		/// timeouts for received messages.
@@ -383,33 +392,23 @@ namespace isobus
 		static constexpr float CURVATURE_COMMAND_RESOLUTION_PER_BIT = 0.25f; ///< The resolution of the message in km-1 per bit
 		static constexpr std::uint16_t ZERO_CURVATURE_INVERSE_KM = 32128; ///< This is the value for zero km-1 for 0.25 km-1 per bit
 
-		/// @brief Sends the agricultural guidance machine info message based on the configured content of agriculturalGuidanceMachineInfoTransmitData
+		/// @brief Sends the agricultural guidance machine info message based on the configured content of guidanceMachineInfoTransmitData
 		/// @returns true if the message was sent, otherwise false
-		bool send_agricultural_guidance_machine_info() const;
+		bool send_guidance_machine_info() const;
 
 		/// @brief Sends the agricultural guidance system command message based on the configured content of guidanceSystemCommandTransmitData
 		/// @returns true if the message was sent, otherwise false
 		bool send_guidance_system_command() const;
 
-		/// @brief Parses a message into a AgriculturalGuidanceMachineInfo class
-		/// @param[in] message The message to parse
-		/// @param[in] machineInfo The class into which the decoded message components will be stored
-		static void parse_agricultural_guidance_machine_info_message(CANMessage *message, std::shared_ptr<AgriculturalGuidanceMachineInfo> machineInfo);
-
-		/// @brief Parses a message into a GuidanceSystemCommand class
-		/// @param[in] message The message to parse
-		/// @param[in] guidanceCommand The class into which the decoded message components will be stored
-		static void parse_agricultural_guidance_system_command_message(CANMessage *message, std::shared_ptr<GuidanceSystemCommand> guidanceCommand);
-
 		ProcessingFlags txFlags; ///< Tx flag for sending messages periodically
-		EventDispatcher<const std::shared_ptr<AgriculturalGuidanceMachineInfo>> agriculturalGuidanceMachineInfoEventPublisher; ///< An event publisher for notifying when new guidance machine info messages are received
-		EventDispatcher<const std::shared_ptr<GuidanceSystemCommand>> guidanceSystemCommandEventPublisher; ///< An event publisher for notifying when new guidance system commands are received
+		EventDispatcher<const std::shared_ptr<GuidanceMachineInfo>, bool> guidanceMachineInfoEventPublisher; ///< An event publisher for notifying when new guidance machine info messages are received
+		EventDispatcher<const std::shared_ptr<GuidanceSystemCommand>, bool> guidanceSystemCommandEventPublisher; ///< An event publisher for notifying when new guidance system commands are received
 		std::shared_ptr<InternalControlFunction> sourceControlFunction; ///< The control function to use when sending messages
 		std::shared_ptr<ControlFunction> destinationControlFunction; ///< The optional destination to which messages will be sent. If nullptr it will be broadcast instead.
-		std::vector<std::shared_ptr<AgriculturalGuidanceMachineInfo>> receivedAgriculturalGuidanceMachineInfoMessages; ///< A list of all received estimated curvatures
+		std::vector<std::shared_ptr<GuidanceMachineInfo>> receivedGuidanceMachineInfoMessages; ///< A list of all received estimated curvatures
 		std::vector<std::shared_ptr<GuidanceSystemCommand>> receivedGuidanceSystemCommandMessages; ///< A list of all received curvature commands and statuses
 		std::uint32_t guidanceSystemCommandTransmitTimestamp_ms = 0; ///< Timestamp used to know when to transmit the guidance system command message
-		std::uint32_t agriculturalGuidanceMachineInfoTransmitTimestamp_ms = 0; ///< Timestamp used to know when to transmit the agricultural guidance machine info message
+		std::uint32_t guidanceMachineInfoTransmitTimestamp_ms = 0; ///< Timestamp used to know when to transmit the guidance machine info message
 		bool initialized = false; ///< Stores if the interface has been initialized
 	};
 } // namespace isobus

--- a/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
@@ -1,7 +1,19 @@
 //================================================================================================
 /// @file isobus_guidance_interface.hpp
 ///
-/// @brief Defines an interface for sending and receiving ISOBUS guidance messages
+/// @brief Defines an interface for sending and receiving ISOBUS guidance messages.
+/// These messages are used to steer ISOBUS compliant machines, steering valves, and
+/// implements in general.
+///
+/// @attention Please use extreme care if you try to steer a machine with this interface!
+/// Remember that this library is licensed under The MIT License, and that by obtaining a
+/// copy of this library and of course by attempting to steer a machine with it, you are agreeing
+/// to our license.
+///
+/// @note These messages are expected to be deprecated or at least made redundant in favor
+/// of Tractor Implement Management (TIM) at some point by the AEF, though the timeline on that
+/// is not known at the time of writing this, and it's likely that many machines will
+/// continue to support this interface going forward due to its simplicity over TIM.
 ///
 /// @author Adrian Del Grosso
 ///
@@ -28,6 +40,9 @@ namespace isobus
 		/// @param[in] destinationControlFunction The destination control function for transmitted messages, or nullptr for broadcasts
 		GuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
+		/// @brief Destructor for the GuidanceInterface
+		~GuidanceInterface();
+
 		/// @brief An interface for sending the agricultural
 		/// guidance system command message.
 		///
@@ -46,6 +61,9 @@ namespace isobus
 				Error = 2,
 				NotAvailable = 3
 			};
+
+			/// @brief A useful way to compare objects to each other for equality
+			bool operator==(const GuidanceSystemCommand &obj);
 
 			/// @brief Sets the curvature command status that will be encoded into
 			/// the CAN message. This parameter indicates whether the guidance system is
@@ -73,7 +91,17 @@ namespace isobus
 			/// @returns Commanded curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
 			float get_curvature() const;
 
+			/// @brief Returns a pointer to the sender of the message. If an ICF is the sender, returns the ICF being used to transmit from.
+			/// @attention The only way you could get an invalid pointer here is if you register a partner, it sends this message, then you delete the partner and
+			/// call this function, as that is the only time the stack deletes a control function. That would be abnormal program flow, but at some point
+			/// the stack will be updated to return a shared or weak pointer instead, but for now please be aware of that limitation.
+			/// Eventually though the message will time-out normally and you can get a new pointer for
+			/// the external CF that replaces the deleted partner.
+			/// @returns The control function sending this instance of the guidance system command message
+			ControlFunction *get_sender_control_function() const;
+
 		private:
+			ControlFunction *controlFunction = nullptr; ///< The CF that is sending the message
 			float commandedCurvature = 0.0f; ///< The commanded curvature in km^-1 (inverse kilometers)
 			CurvatureCommandStatus commandedStatus = CurvatureCommandStatus::NotAvailable; ///< The current status for the command
 		};
@@ -93,6 +121,67 @@ namespace isobus
 				NotAvailable = 3
 			};
 
+			/// @brief Machine steering system request to the automatic guidance system to
+			/// change Curvature Command Status state from "Intended to steer" to "Not intended to steer".
+			enum class RequestResetCommandStatus : std::uint8_t
+			{
+				ResetNotRequired = 0,
+				ResetRequired = 1,
+				Error = 2,
+				NotAvailable = 3
+			};
+
+			/// @brief A typical, generic 2 bit value in J1939 with no supersceding definition in ISO 11783
+			enum class GenericSAEbs02SlotValue : std::uint8_t
+			{
+				DisabledOffPassive = 0,
+				EnabledOnActive = 1,
+				ErrorIndication = 2,
+				NotAvailableTakeNoAction = 3
+			};
+
+			/// @brief This parameter is used to report the steering system's present limit status
+			/// associated with guidance commands that are persistent (i.e. not transient/temporary/one-shot).
+			enum class GuidanceLimitStatus : std::uint8_t
+			{
+				NotLimited = 0, ///< Not limited
+				OperatorLimitedControlled = 1, ///< Request cannot be implemented
+				LimitedHigh = 2, ///< Only lower command values result in a change
+				LimitedLow = 3, ///< Only higher command values result in a change
+				Reserved_1 = 4, ///< Reserved
+				Reserved_2 = 5, ///< Reserved
+				NonRecoverableFault = 6, ///< Non-recoverable fault
+				NotAvailable = 7 ///< Parameter not supported
+			};
+
+			/// @brief This parameter is used to indicate why the guidance system cannot currently accept remote
+			/// commands or has most recently stopped accepting remote commands.
+			enum class GuidanceSystemCommandExitReasonCode
+			{
+				NoReasonAllClear = 0,
+				RequiredLevelOfOperatorPresenceAwarenessNotDetected = 1,
+				ImplementReleasedControlOfFunction = 2,
+				OperatorOverrideOfFunction = 3,
+				OperatorControlNotInValidPosition = 4,
+				RemoteCommandTimeout = 5,
+				RemoteCommandOutOfRangeInvalid = 6,
+				FunctionNotCalibrated = 7,
+				OperatorControlFault = 8,
+				FunctionFault = 9,
+				HydraulicOilLevelTooLow = 20,
+				HydraulicOilTemperatureTooLow = 21,
+				VehicleTransmissionGearDoesNotAllowRemoteCommands = 22, ///< park, etc.
+				VehicleSpeedTooLow = 23,
+				VehicleSpeedTooHigh = 24,
+				AlternateGuidanceSystemActive = 25,
+				ControlUnitInDiagnosticMode = 26,
+				Error = 62,
+				NotAvailable = 63 ///< Parameter not supported
+			};
+
+			/// @brief A useful way to compare objects to each other for equality
+			bool operator==(const AgriculturalGuidanceMachineInfo &obj);
+
 			/// @brief Sets the estimated course curvature over ground for the machine.
 			/// @param[in] curvature The curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
 			void set_estimated_curvature(float curvature);
@@ -101,38 +190,132 @@ namespace isobus
 			/// @returns The estimated curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
 			float get_estimated_curvature() const;
 
+			/// @brief Sets the mechanical system lockout state
+			/// @param[in] state The mechanical system lockout state to report
+			void set_mechanical_system_lockout_state(MechanicalSystemLockout state);
+
+			/// @brief Returns the mechanical system lockout state
+			/// @returns The mechanical system lockout state being reported
+			MechanicalSystemLockout get_mechanical_system_lockout() const;
+
+			/// @brief Sets the guidance system's readiness state to report
+			/// @param[in] state The state to report. See definition of GenericSAEbs02SlotValue
+			void set_guidance_steering_system_readiness_state(GenericSAEbs02SlotValue state);
+
+			/// @brief Returns the guidance system's readiness state for steering
+			/// @returns The guidance system's readiness state for steering
+			GenericSAEbs02SlotValue get_guidance_steering_system_readiness_state() const;
+
+			void set_guidance_steering_input_position_status(GenericSAEbs02SlotValue state);
+
+			GenericSAEbs02SlotValue get_guidance_steering_input_position_status() const;
+
+			void set_request_reset_command_status(RequestResetCommandStatus state);
+
+			RequestResetCommandStatus get_request_reset_command_status() const;
+
+			void set_guidance_limit_status(GuidanceLimitStatus status);
+
+			GuidanceLimitStatus get_guidance_limit_status() const;
+
+			void set_guidance_system_command_exit_reason_code(std::uint8_t exitCode);
+
+			std::uint8_t get_guidance_system_command_exit_reason_code() const;
+
+			void set_guidance_system_remote_engage_switch_status(GenericSAEbs02SlotValue switchStatus);
+
+			GenericSAEbs02SlotValue get_guidance_system_remote_engage_switch_status() const;
+
+			/// @brief Returns a pointer to the sender of the message. If an ICF is the sender, returns the ICF being used to transmit from.
+			/// @attention The only way you could get an invalid pointer here is if you register a partner, it sends this message, then you delete the partner and
+			/// call this function, as that is the only time the stack deletes a control function. That would be abnormal program flow, but at some point
+			/// the stack will be updated to return a shared or weak pointer instead, but for now please be aware of that limitation.
+			/// Eventually though the message will time-out normally and you can get a new pointer for
+			/// the external CF that replaces the deleted partner.
+			/// @returns The control function sending this instance of the guidance system command message
+			ControlFunction *get_sender_control_function() const;
+
 		private:
-			float estimatedCurvature = 0.0f; ///< Curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
+			ControlFunction *controlFunction = nullptr; ///< The CF that is sending the message
+			float estimatedCurvature = 0.0f; ///< Curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1 (SPN 5238)
+			MechanicalSystemLockout mechanicalSystemLockoutState = MechanicalSystemLockout::NotAvailable; ///< The reported state of the mechanical system lockout switch (SPN 5243)
+			GenericSAEbs02SlotValue guidanceSteeringSystemReadinessState = GenericSAEbs02SlotValue::NotAvailableTakeNoAction; ///< The reported state of the steering system's readiness to steer (SPN 5242)
+			GenericSAEbs02SlotValue guidanceSteeringInputPositionStatus = GenericSAEbs02SlotValue::NotAvailableTakeNoAction; ///< The reported state of the steering input position. (SPN 5241)
+			GenericSAEbs02SlotValue guidanceSystemRemoteEngageSwitchStatus = GenericSAEbs02SlotValue::NotAvailableTakeNoAction; ///< The reported state of the remote engage switch (SPN 9726)
+			RequestResetCommandStatus requestResetCommandStatus = RequestResetCommandStatus::NotAvailable; ///< The reported state of the request reset command (SPN 5240)
+			GuidanceLimitStatus guidanceLimitStatus = GuidanceLimitStatus::NotAvailable; ///< The steering system's present limit status associated with guidance commands that are persistent (SPN 5726)
+			std::uint8_t guidanceSystemCommandExitReasonCode = static_cast<std::uint8_t>(GuidanceSystemCommandExitReasonCode::NotAvailable); ///< The exit code for guidance, stored as a u8 to preserve manufacturer specific values (SPN 5725)
 		};
 
+		/// @brief Sets up the class and registers it to recieve callbacks from the network manager for processing
+		/// guidance messages. The class will not recieve messages if this is not called.
 		void initialize();
 
+		/// @brief Use this to configure the transmission of the guidance machine info message from your application. If you pass in an internal control function
+		/// to the constructor of this class, then this message is available to be sent.
 		AgriculturalGuidanceMachineInfo AgriculturalGuidanceMachineInfoTransmitData;
+
+		/// @brief Use this to configure transmission the guidance system command message from your application. If you pass in an internal control function
+		/// to the constructor of this class, then this message is available to be sent.
 		GuidanceSystemCommand GuidanceSystemCommandTransmitData;
 
+		/// @brief Returns the number of received, unique guidance system command sources
+		/// @returns The number of CFs sending the guidance system command either as a broadcast, or to our internal control function
 		std::size_t get_number_received_guidance_system_command_sources() const;
+
+		/// @brief Returns the number of received, unique guidance machine info message sources
+		/// @returns The number of CFs sending the guidance machine info message either as a broadcast, or to our internal control function
 		std::size_t get_number_received_agricultural_guidance_machine_info_message_sources() const;
 
-		bool send_guidance_curvature_command();
+		std::shared_ptr<AgriculturalGuidanceMachineInfo> get_received_agricultural_guidance_machine_info(std::size_t index);
+		std::shared_ptr<GuidanceSystemCommand> get_received_guidance_system_command(std::size_t index);
 
-		virtual void update();
+		/// @brief Call this cyclically to update the interface. Transmits messages if needed and processes
+		/// timeouts for received messages.
+		void update();
 
-	private:
+	protected:
+		/// @brief Enumerates a set of flags to manage transmitting messages owned by this interface
 		enum class TransmitFlags : std::uint32_t
 		{
-			SendGuidanceSystemCommand = 0,
-			SendGuidanceMachineInfo,
+			SendGuidanceSystemCommand = 0, ///< A flag to manage sending the guidance system command message
+			SendGuidanceMachineInfo, ///< A flag to manage sending the guidance machine info message
 
-			NumberOfFlags
+			NumberOfFlags ///< The number of flags in this enumeration
 		};
 
+		/// @brief Processes one flag (which sends the associated message)
+		/// @param[in] flag The flag to process
+		/// @param[in] parentPointer A pointer to the interface instance
 		static void process_flags(std::uint32_t flag, void *parentPointer);
+
+		/// @brief Processes a CAN message
+		/// @param[in] message The CAN message being received
+		/// @param[in] parentPointer A context variable to find the relevant instance of this class
+		static void process_rx_message(CANMessage *message, void *parentPointer);
+
+		static constexpr std::uint32_t GUIDANCE_MESSAGE_TX_INTERVAL_MS = 100; ///< How often guidance messages are sent, defined in ISO 11783-7
+		static constexpr std::uint32_t GUIDANCE_MESSAGE_TIMEOUT_MS = 150; ///< Amount of time before a guidance message is stale. We currently tolerate 50ms of delay.
+		static constexpr float CURVATURE_COMMAND_OFFSET_INVERSE_KM = 8032.0f; ///< Constant offset for curvature being sent on the bus in km-1
+		static constexpr float CURVATURE_COMMAND_MAX_INVERSE_KM = 8031.75f; ///< The maximum curvature that can be encoded once scaling is applied
+		static constexpr float CURVATURE_COMMAND_RESOLUTION_PER_BIT = 0.25f; ///< The resolution of the message in km-1 per bit
+		static constexpr std::uint16_t ZERO_CURVATURE_INVERSE_KM = 32128; ///< This is the value for zero km-1 for 0.25 km-1 per bit
+
+		/// @brief Sends the agricultural guidance machine info message based on the configured content of AgriculturalGuidanceMachineInfoTransmitData
+		/// @returns true if the message was sent, otherwise false
+		bool send_agricultural_guidance_machine_info() const;
+
+		/// @brief Sends the agricultural guidance system command message based on the configured content of GuidanceSystemCommandTransmitData
+		/// @returns true if the message was sent, otherwise false
+		bool send_guidance_system_command() const;
 
 		ProcessingFlags txFlags; ///< Tx flag for sending messages periodically
 		std::shared_ptr<InternalControlFunction> sourceControlFunction; ///< The control function to use when sending messages
 		std::shared_ptr<ControlFunction> destinationControlFunction; ///< The optional destination to which messages will be sent. If nullptr it will be broadcast instead.
-		std::vector<AgriculturalGuidanceMachineInfo> receivedAgriculturalGuidanceMachineInfoMessages; ///< A list of all received estimated curvatures
-		std::vector<GuidanceSystemCommand> receivedGuidanceSystemCommandMessages; ///< A list of all received curvature commands and statuses
+		std::vector<std::shared_ptr<AgriculturalGuidanceMachineInfo>> receivedAgriculturalGuidanceMachineInfoMessages; ///< A list of all received estimated curvatures
+		std::vector<std::shared_ptr<GuidanceSystemCommand>> receivedGuidanceSystemCommandMessages; ///< A list of all received curvature commands and statuses
+		std::uint32_t guidanceSystemCommandTransmitTimestamp_ms = 0; ///< Timestamp used to know when to transmit the guidance system command message
+		std::uint32_t agriculturalGuidanceMachineInfoTransmitTimestamp_ms = 0; ///< Timestamp used to know when to transmit the agricultural guidance machine info message
 		bool initialized = false; ///< Stores if the interface has been initialized
 	};
 } // namespace isobus

--- a/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
@@ -62,6 +62,8 @@ namespace isobus
 				NotAvailable = 3
 			};
 
+			GuidanceSystemCommand() = default;
+
 			/// @brief A useful way to compare objects to each other for equality
 			bool operator==(const GuidanceSystemCommand &obj);
 
@@ -206,8 +208,12 @@ namespace isobus
 			/// @returns The guidance system's readiness state for steering
 			GenericSAEbs02SlotValue get_guidance_steering_system_readiness_state() const;
 
+			/// @brief Sets the guidance steering input position state
+			/// @param[in] state The state to set for the guidance steering input position
 			void set_guidance_steering_input_position_status(GenericSAEbs02SlotValue state);
 
+			/// @brief Returns the guidance steering input position state
+			/// @returns Guidance steering input position state
 			GenericSAEbs02SlotValue get_guidance_steering_input_position_status() const;
 
 			void set_request_reset_command_status(RequestResetCommandStatus state);

--- a/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
@@ -103,9 +103,18 @@ namespace isobus
 			/// @returns The control function sending this instance of the guidance system command message
 			ControlFunction *get_sender_control_function() const;
 
+			/// @brief Sets the timestamp for when the message was received or sent
+			/// @param[in] timestamp The timestamp, in milliseconds, when the message was sent or received
+			void set_timestamp_ms(std::uint32_t timestamp);
+
+			/// @brief Returns the timestamp for when the message was received, in milliseconds
+			/// @returns The timestamp for when the message was received, in milliseconds
+			std::uint32_t get_timestamp_ms() const;
+
 		private:
 			ControlFunction *controlFunction = nullptr; ///< The CF that is sending the message
 			float commandedCurvature = 0.0f; ///< The commanded curvature in km^-1 (inverse kilometers)
+			std::uint32_t timestamp_ms = 0; ///< A timestamp for when the message was released in milliseconds
 			CurvatureCommandStatus commandedStatus = CurvatureCommandStatus::NotAvailable; ///< The current status for the command
 		};
 
@@ -276,9 +285,18 @@ namespace isobus
 			/// @returns The control function sending this instance of the guidance system command message
 			ControlFunction *get_sender_control_function() const;
 
+			/// @brief Sets the timestamp for when the message was received or sent
+			/// @param[in] timestamp The timestamp, in milliseconds, when the message was sent or received
+			void set_timestamp_ms(std::uint32_t timestamp);
+
+			/// @brief Returns the timestamp for when the message was received, in milliseconds
+			/// @returns The timestamp for when the message was received, in milliseconds
+			std::uint32_t get_timestamp_ms() const;
+
 		private:
 			ControlFunction *controlFunction = nullptr; ///< The CF that is sending the message
 			float estimatedCurvature = 0.0f; ///< Curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1 (SPN 5238)
+			std::uint32_t timestamp_ms = 0; ///< A timestamp for when the message was released in milliseconds
 			MechanicalSystemLockout mechanicalSystemLockoutState = MechanicalSystemLockout::NotAvailable; ///< The reported state of the mechanical system lockout switch (SPN 5243)
 			GenericSAEbs02SlotValue guidanceSteeringSystemReadinessState = GenericSAEbs02SlotValue::NotAvailableTakeNoAction; ///< The reported state of the steering system's readiness to steer (SPN 5242)
 			GenericSAEbs02SlotValue guidanceSteeringInputPositionStatus = GenericSAEbs02SlotValue::NotAvailableTakeNoAction; ///< The reported state of the steering input position. (SPN 5241)
@@ -325,6 +343,14 @@ namespace isobus
 		/// @note Only one device on the bus will send this normally, but we provide a generic way to get
 		/// an arbitrary number of these commands. So generally using only index 0 will be acceptable.
 		std::shared_ptr<GuidanceSystemCommand> get_received_guidance_system_command(std::size_t index);
+
+		/// @brief Returns an event dispatcher which you can use to get callbacks when new/updated guidance machine info messages are received.
+		/// @returns The event publisher for guidance machine info messages
+		EventDispatcher<const std::shared_ptr<AgriculturalGuidanceMachineInfo>> &get_agricultural_guidance_machine_info_event_publisher();
+
+		/// @brief Returns an event dispatcher which you can use to get callbacks when new/updated guidance system command messages are received.
+		/// @returns The event publisher for guidance system command messages
+		EventDispatcher<const std::shared_ptr<GuidanceSystemCommand>> &get_guidance_guidance_system_command_event_publisher();
 
 		/// @brief Call this cyclically to update the interface. Transmits messages if needed and processes
 		/// timeouts for received messages.
@@ -376,6 +402,8 @@ namespace isobus
 		static void parse_agricultural_guidance_system_command_message(CANMessage *message, std::shared_ptr<GuidanceSystemCommand> guidanceCommand);
 
 		ProcessingFlags txFlags; ///< Tx flag for sending messages periodically
+		EventDispatcher<const std::shared_ptr<AgriculturalGuidanceMachineInfo>> agriculturalGuidanceMachineInfoEventPublisher; ///< An event publisher for notifying when new guidance machine info messages are received
+		EventDispatcher<const std::shared_ptr<GuidanceSystemCommand>> guidanceSystemCommandEventPublisher; ///< An event publisher for notifying when new guidance system commands are received
 		std::shared_ptr<InternalControlFunction> sourceControlFunction; ///< The control function to use when sending messages
 		std::shared_ptr<ControlFunction> destinationControlFunction; ///< The optional destination to which messages will be sent. If nullptr it will be broadcast instead.
 		std::vector<std::shared_ptr<AgriculturalGuidanceMachineInfo>> receivedAgriculturalGuidanceMachineInfoMessages; ///< A list of all received estimated curvatures

--- a/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
@@ -1,0 +1,140 @@
+//================================================================================================
+/// @file isobus_guidance_interface.hpp
+///
+/// @brief Defines an interface for sending and receiving ISOBUS guidance messages
+///
+/// @author Adrian Del Grosso
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
+#ifndef ISOBUS_GUIDANCE_INTERFACE_HPP
+#define ISOBUS_GUIDANCE_INTERFACE_HPP
+
+#include "isobus/isobus/can_internal_control_function.hpp"
+#include "isobus/utility/event_dispatcher.hpp"
+#include "isobus/utility/processing_flags.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace isobus
+{
+	/// @brief An interface for sending and receiving ISOBUS guidance messages
+	class GuidanceInterface
+	{
+	public:
+		/// @brief Constructor for a GuidanceInterface
+		/// @param[in] sourceControlFunction The internal control function to use when sending messages, or nullptr for listen only
+		/// @param[in] destinationControlFunction The destination control function for transmitted messages, or nullptr for broadcasts
+		GuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
+
+		/// @brief An interface for sending the agricultural
+		/// guidance system command message.
+		///
+		/// @details This message is sent by an automatic guidance control system to the
+		/// machine steering system. It provides steering commands
+		/// and serves as heartbeat between guidance system and steering control system.
+		class GuidanceSystemCommand
+		{
+		public:
+			/// @brief This parameter indicates whether the guidance system is
+			/// attempting to control steering with this command.
+			enum class CurvatureCommandStatus : std::uint8_t
+			{
+				NotIntendedToSteer = 0, ///< Steering Disengaged
+				IntendedToSteer = 1, ///< Steering Engaged
+				Error = 2,
+				NotAvailable = 3
+			};
+
+			/// @brief Sets the curvature command status that will be encoded into
+			/// the CAN message. This parameter indicates whether the guidance system is
+			/// attempting to control steering with this command
+			/// @param[in] newStatus The status to encode into the message
+			void set_status(CurvatureCommandStatus newStatus);
+
+			/// @brief Returns the curvature command status that was set with set_status
+			/// @returns The curvature command status that was set with set_status
+			CurvatureCommandStatus get_status() const;
+
+			/// @brief Desired course curvature over ground that a machine's
+			/// steering system is required to achieve.
+			/// @details The value you set here will be encoded into the
+			/// guidance curvature command message.
+			///
+			/// The desired path is determined by the automatic guidance system expressed
+			/// as the inverse of the instantaneous radius of curvature of the turn.
+			/// Curvature is positive when the vehicle is moving forward and turning to the driver's right
+			///
+			/// @param[in] curvature Commanded curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
+			void set_curvature(float curvature);
+
+			/// @brief Returns the curvature command that was set with set_curvature
+			/// @returns Commanded curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
+			float get_curvature() const;
+
+		private:
+			float commandedCurvature = 0.0f; ///< The commanded curvature in km^-1 (inverse kilometers)
+			CurvatureCommandStatus commandedStatus = CurvatureCommandStatus::NotAvailable; ///< The current status for the command
+		};
+
+		/// @brief An interface for sending and receiving the ISOBUS agricultural guidance machine message
+		class AgriculturalGuidanceMachineInfo
+		{
+		public:
+			/// @brief State of a lockout switch that allows operators to
+			/// disable automatic steering system functions.
+			/// @details https://www.isobus.net/isobus/pGNAndSPN/1221?type=SPN
+			enum class MechanicalSystemLockout : std::uint8_t
+			{
+				NotActive = 0,
+				Active = 1,
+				Error = 2,
+				NotAvailable = 3
+			};
+
+			/// @brief Sets the estimated course curvature over ground for the machine.
+			/// @param[in] curvature The curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
+			void set_estimated_curvature(float curvature);
+
+			/// @brief Returns the estimated curvature that was previously set with set_estimated_curvature
+			/// @returns The estimated curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
+			float get_estimated_curvature() const;
+
+		private:
+			float estimatedCurvature = 0.0f; ///< Curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
+		};
+
+		void initialize();
+
+		AgriculturalGuidanceMachineInfo AgriculturalGuidanceMachineInfoTransmitData;
+		GuidanceSystemCommand GuidanceSystemCommandTransmitData;
+
+		std::size_t get_number_received_guidance_system_command_sources() const;
+		std::size_t get_number_received_agricultural_guidance_machine_info_message_sources() const;
+
+		bool send_guidance_curvature_command();
+
+		virtual void update();
+
+	private:
+		enum class TransmitFlags : std::uint32_t
+		{
+			SendGuidanceSystemCommand = 0,
+			SendGuidanceMachineInfo,
+
+			NumberOfFlags
+		};
+
+		static void process_flags(std::uint32_t flag, void *parentPointer);
+
+		ProcessingFlags txFlags; ///< Tx flag for sending messages periodically
+		std::shared_ptr<InternalControlFunction> sourceControlFunction; ///< The control function to use when sending messages
+		std::shared_ptr<ControlFunction> destinationControlFunction; ///< The optional destination to which messages will be sent. If nullptr it will be broadcast instead.
+		std::vector<AgriculturalGuidanceMachineInfo> receivedAgriculturalGuidanceMachineInfoMessages; ///< A list of all received estimated curvatures
+		std::vector<GuidanceSystemCommand> receivedGuidanceSystemCommandMessages; ///< A list of all received curvature commands and statuses
+		bool initialized = false; ///< Stores if the interface has been initialized
+	};
+} // namespace isobus
+
+#endif // ISOBUS_GUIDANCE_HPP

--- a/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
@@ -42,8 +42,8 @@ namespace isobus
 		/// @param[in] sentMachineInfoPeriodically If true, the machine info message will be sent periodically. This should (only) be used by the steering controller itself.
 		AgriculturalGuidanceInterface(std::shared_ptr<InternalControlFunction> source,
 		                              std::shared_ptr<ControlFunction> destination,
-		                              bool sentSystemCommandPeriodically = false,
-		                              bool sentMachineInfoPeriodically = false);
+		                              bool enableSendingSystemCommandPeriodically = false,
+		                              bool enableSendingMachineInfoPeriodically = false);
 
 		/// @brief Destructor for the AgriculturalGuidanceInterface
 		~AgriculturalGuidanceInterface();
@@ -69,7 +69,7 @@ namespace isobus
 
 			/// @brief Constructor for a GuidanceSystemCommand
 			/// @param[in] sender The control function that is sending this message
-			GuidanceSystemCommand(ControlFunction *sender);
+			explicit GuidanceSystemCommand(ControlFunction *sender);
 
 			/// @brief Sets the curvature command status that will be encoded into
 			/// the CAN message. This parameter indicates whether the guidance system is
@@ -198,7 +198,7 @@ namespace isobus
 
 			/// @brief Constructor for a GuidanceMachineInfo
 			/// @param[in] sender The control function that is sending this message
-			GuidanceMachineInfo(ControlFunction *sender);
+			explicit GuidanceMachineInfo(ControlFunction *sender);
 
 			/// @brief Sets the estimated course curvature over ground for the machine.
 			/// @param[in] curvature The curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1

--- a/isobus/src/isobus_guidance_interface.cpp
+++ b/isobus/src/isobus_guidance_interface.cpp
@@ -1,0 +1,92 @@
+#include "isobus/isobus/isobus_guidance_interface.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
+#include "isobus/isobus/can_stack_logger.hpp"
+
+namespace isobus
+{
+	GuidanceInterface::GuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination) :
+	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberOfFlags), process_flags, this),
+	  sourceControlFunction(source),
+	  destinationControlFunction(destination)
+	{
+	}
+
+	void GuidanceInterface::GuidanceSystemCommand::set_status(CurvatureCommandStatus newStatus)
+	{
+		commandedStatus = newStatus;
+	}
+
+	GuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus GuidanceInterface::GuidanceSystemCommand::get_status() const
+	{
+		return commandedStatus;
+	}
+
+	void GuidanceInterface::GuidanceSystemCommand::set_curvature(float curvature)
+	{
+		commandedCurvature = curvature;
+	}
+
+	float GuidanceInterface::GuidanceSystemCommand::get_curvature() const
+	{
+		return commandedCurvature;
+	}
+
+	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_estimated_curvature(float curvature)
+	{
+		estimatedCurvature = curvature;
+	}
+
+	float GuidanceInterface::AgriculturalGuidanceMachineInfo::get_estimated_curvature() const
+	{
+		return estimatedCurvature;
+	}
+
+	void GuidanceInterface::initialize()
+	{
+		if (!initialized)
+		{
+			initialized = true;
+		}
+	}
+
+	std::size_t GuidanceInterface::get_number_received_guidance_system_command_sources() const
+	{
+		return receivedGuidanceSystemCommandMessages.size();
+	}
+
+	std::size_t GuidanceInterface::get_number_received_agricultural_guidance_machine_info_message_sources() const
+	{
+		return receivedAgriculturalGuidanceMachineInfoMessages.size();
+	}
+
+	bool GuidanceInterface::send_guidance_curvature_command()
+	{
+		bool retVal = false;
+
+		if (nullptr != sourceControlFunction)
+		{
+			//retVal = CANNetworkManager::CANNetwork.send_can_message()
+		}
+		return retVal;
+	}
+
+	void GuidanceInterface::process_flags(std::uint32_t flag, void *parentPointer)
+	{
+		if (nullptr != parentPointer)
+		{
+			auto targetInterface = static_cast<GuidanceInterface *>(parentPointer);
+			bool transmitSuccessful = false;
+
+			switch (flag)
+			{
+				default:
+					break;
+			}
+
+			if (false == transmitSuccessful)
+			{
+				targetInterface->txFlags.set_flag(flag);
+			}
+		}
+	}
+} // namespace isobus

--- a/isobus/src/isobus_guidance_interface.cpp
+++ b/isobus/src/isobus_guidance_interface.cpp
@@ -1,6 +1,33 @@
+//================================================================================================
+/// @file isobus_guidance_interface.cpp
+///
+/// @brief Implements an interface for sending and receiving ISOBUS guidance messages.
+/// These messages are used to steer ISOBUS compliant machines, steering valves, and
+/// implements in general.
+///
+/// @attention Please use extreme care if you try to steer a machine with this interface!
+/// Remember that this library is licensed under The MIT License, and that by obtaining a
+/// copy of this library and of course by attempting to steer a machine with it, you are agreeing
+/// to our license.
+///
+/// @note These messages are expected to be deprecated or at least made redundant in favor
+/// of Tractor Implement Management (TIM) at some point by the AEF, though the timeline on that
+/// is not known at the time of writing this, and it's likely that many machines will
+/// continue to support this interface going forward due to its simplicity over TIM.
+///
+/// @author Adrian Del Grosso
+///
+/// @copyright 2023 Adrian Del Grosso
+//================================================================================================
 #include "isobus/isobus/isobus_guidance_interface.hpp"
+#include "isobus/isobus/can_general_parameter_group_numbers.hpp"
+#include "isobus/isobus/can_message.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_stack_logger.hpp"
+#include "isobus/utility/system_timing.hpp"
+
+#include <cassert>
+#include <cmath>
 
 namespace isobus
 {
@@ -9,6 +36,20 @@ namespace isobus
 	  sourceControlFunction(source),
 	  destinationControlFunction(destination)
 	{
+	}
+
+	GuidanceInterface::~GuidanceInterface()
+	{
+		if (initialized)
+		{
+			CANNetworkManager::CANNetwork.remove_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceMachineInfo), process_rx_message, this);
+			CANNetworkManager::CANNetwork.remove_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceSystemCommand), process_rx_message, this);
+		}
+	}
+
+	bool GuidanceInterface::GuidanceSystemCommand::operator==(const GuidanceSystemCommand &obj)
+	{
+		return obj.controlFunction == this->controlFunction;
 	}
 
 	void GuidanceInterface::GuidanceSystemCommand::set_status(CurvatureCommandStatus newStatus)
@@ -31,6 +72,11 @@ namespace isobus
 		return commandedCurvature;
 	}
 
+	bool GuidanceInterface::AgriculturalGuidanceMachineInfo::operator==(const AgriculturalGuidanceMachineInfo &obj)
+	{
+		return obj.controlFunction == this->controlFunction;
+	}
+
 	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_estimated_curvature(float curvature)
 	{
 		estimatedCurvature = curvature;
@@ -41,10 +87,92 @@ namespace isobus
 		return estimatedCurvature;
 	}
 
+	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_mechanical_system_lockout_state(MechanicalSystemLockout state)
+	{
+		mechanicalSystemLockoutState = state;
+	}
+
+	GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout GuidanceInterface::AgriculturalGuidanceMachineInfo::get_mechanical_system_lockout() const
+	{
+		return mechanicalSystemLockoutState;
+	}
+
+	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_steering_system_readiness_state(GenericSAEbs02SlotValue state)
+	{
+		guidanceSteeringSystemReadinessState = state;
+	}
+
+	GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_steering_system_readiness_state() const
+	{
+		return guidanceSteeringSystemReadinessState;
+	}
+
+	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_steering_input_position_status(GenericSAEbs02SlotValue state)
+	{
+		guidanceSteeringInputPositionStatus = state;
+	}
+
+	GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_steering_input_position_status() const
+	{
+		return guidanceSteeringInputPositionStatus;
+	}
+
+	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_request_reset_command_status(RequestResetCommandStatus state)
+	{
+		requestResetCommandStatus = state;
+	}
+
+	GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus GuidanceInterface::AgriculturalGuidanceMachineInfo::get_request_reset_command_status() const
+	{
+		return requestResetCommandStatus;
+	}
+
+	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_limit_status(GuidanceLimitStatus status)
+	{
+		guidanceLimitStatus = status;
+	}
+
+	GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_limit_status() const
+	{
+		return guidanceLimitStatus;
+	}
+
+	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_system_command_exit_reason_code(std::uint8_t exitCode)
+	{
+		guidanceSystemCommandExitReasonCode = exitCode;
+	}
+
+	std::uint8_t GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_system_command_exit_reason_code() const
+	{
+		return guidanceSystemCommandExitReasonCode;
+	}
+
+	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_system_remote_engage_switch_status(GenericSAEbs02SlotValue switchStatus)
+	{
+		guidanceSystemRemoteEngageSwitchStatus = switchStatus;
+	}
+
+	GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_system_remote_engage_switch_status() const
+	{
+		return guidanceSystemRemoteEngageSwitchStatus;
+	}
+
+	ControlFunction *GuidanceInterface::AgriculturalGuidanceMachineInfo::get_sender_control_function() const
+	{
+		return controlFunction;
+	}
+
 	void GuidanceInterface::initialize()
 	{
 		if (!initialized)
 		{
+			if (nullptr != sourceControlFunction)
+			{
+				// Make sure you know what you are doing... consider reviewing the guidance messaging in ISO 11783-7 if you haven't already.
+				CANStackLogger::warn("[Guidance]: Use extreme caution! You have configured the ISOBUS guidance interface with the ability to steer a machine.");
+			}
+			CANNetworkManager::CANNetwork.add_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceMachineInfo), process_rx_message, this);
+			CANNetworkManager::CANNetwork.add_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceSystemCommand), process_rx_message, this);
 			initialized = true;
 		}
 	}
@@ -59,15 +187,113 @@ namespace isobus
 		return receivedAgriculturalGuidanceMachineInfoMessages.size();
 	}
 
-	bool GuidanceInterface::send_guidance_curvature_command()
+	bool GuidanceInterface::send_guidance_system_command() const
 	{
 		bool retVal = false;
 
 		if (nullptr != sourceControlFunction)
 		{
-			//retVal = CANNetworkManager::CANNetwork.send_can_message()
+			float scaledCurvature = std::roundf(4 * ((GuidanceSystemCommandTransmitData.get_curvature() + CURVATURE_COMMAND_OFFSET_INVERSE_KM) / CURVATURE_COMMAND_RESOLUTION_PER_BIT)) / 4.0f;
+			std::uint16_t encodedCurvature = ZERO_CURVATURE_INVERSE_KM;
+
+			if (scaledCurvature > CURVATURE_COMMAND_MAX_INVERSE_KM)
+			{
+				encodedCurvature = 32127 + ZERO_CURVATURE_INVERSE_KM; // Clamp to maximum value
+				CANStackLogger::warn("[Guidance]: Transmitting a commanded curvature clamped to maximum value. Verify guidance calculations are accurate!");
+			}
+			else if (scaledCurvature < 0) // 0 In this case is -8032 km-1 due to the addition of the offset earlier
+			{
+				encodedCurvature = 0; // Clamp to minimum value
+				CANStackLogger::warn("[Guidance]: Transmitting a commanded curvature clamped to minimum value. Verify guidance calculations are accurate!");
+			}
+			else
+			{
+				encodedCurvature = scaledCurvature;
+			}
+
+			std::array<std::uint8_t, CAN_DATA_LENGTH> buffer = { static_cast<std::uint8_t>(encodedCurvature & 0xFF),
+				                                                   static_cast<std::uint8_t>((encodedCurvature >> 8) & 0xFF),
+				                                                   static_cast<std::uint8_t>(static_cast<std::uint8_t>(GuidanceSystemCommandTransmitData.get_status()) | static_cast<std::uint8_t>(0xFC)),
+				                                                   0xFF,
+				                                                   0xFF,
+				                                                   0xFF,
+				                                                   0xFF,
+				                                                   0xFF };
+
+			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceSystemCommand),
+			                                                        buffer.data(),
+			                                                        buffer.size(),
+			                                                        sourceControlFunction.get(),
+			                                                        destinationControlFunction.get(),
+			                                                        CANIdentifier::Priority3);
 		}
 		return retVal;
+	}
+
+	bool GuidanceInterface::send_agricultural_guidance_machine_info() const
+	{
+		bool retVal = false;
+
+		if (nullptr != sourceControlFunction)
+		{
+			float scaledCurvature = std::roundf(4 * ((AgriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature() + CURVATURE_COMMAND_OFFSET_INVERSE_KM) / CURVATURE_COMMAND_RESOLUTION_PER_BIT)) / 4.0f;
+			std::uint16_t encodedCurvature = ZERO_CURVATURE_INVERSE_KM;
+
+			if (scaledCurvature > CURVATURE_COMMAND_MAX_INVERSE_KM)
+			{
+				encodedCurvature = 32127 + ZERO_CURVATURE_INVERSE_KM; // Clamp to maximum value
+				CANStackLogger::warn("[Guidance]: Transmitting an estimated curvature clamped to maximum value. Verify guidance calculations are accurate!");
+			}
+			else if (scaledCurvature < 0) // 0 In this case is -8032 km-1 due to the addition of the offset earlier
+			{
+				encodedCurvature = 0; // Clamp to minimum value
+				CANStackLogger::warn("[Guidance]: Transmitting an estimated curvature clamped to minimum value. Verify guidance calculations are accurate!");
+			}
+			else
+			{
+				encodedCurvature = scaledCurvature;
+			}
+
+			std::array<std::uint8_t, CAN_DATA_LENGTH> buffer = {
+				static_cast<std::uint8_t>(encodedCurvature & 0xFF),
+				static_cast<std::uint8_t>((encodedCurvature >> 8) & 0xFF),
+				static_cast<std::uint8_t>((static_cast<std::uint8_t>(AgriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout()) & 0x03) |
+				                          ((static_cast<std::uint8_t>(AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state()) & 0x03) << 2) |
+				                          ((static_cast<std::uint8_t>(AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status()) & 0x03) << 4) |
+				                          ((static_cast<std::uint8_t>(AgriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status()) & 0x03) << 6)),
+				static_cast<std::uint8_t>(static_cast<std::uint8_t>(AgriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status()) << 5),
+				static_cast<std::uint8_t>((AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code() & 0x3F) |
+				                          (static_cast<std::uint8_t>(AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status()) << 6)),
+				0xFF, // Reserved
+				0xFF // Reserved
+			};
+
+			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceMachineInfo),
+			                                                        buffer.data(),
+			                                                        buffer.size(),
+			                                                        sourceControlFunction.get(),
+			                                                        destinationControlFunction.get(),
+			                                                        CANIdentifier::Priority3);
+		}
+		return retVal;
+	}
+
+	void GuidanceInterface::update()
+	{
+		if (nullptr != sourceControlFunction)
+		{
+			if (SystemTiming::time_expired_ms(agriculturalGuidanceMachineInfoTransmitTimestamp_ms, GUIDANCE_MESSAGE_TX_INTERVAL_MS))
+			{
+				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::SendGuidanceMachineInfo));
+				agriculturalGuidanceMachineInfoTransmitTimestamp_ms = SystemTiming::get_timestamp_ms();
+			}
+			if (SystemTiming::time_expired_ms(guidanceSystemCommandTransmitTimestamp_ms, GUIDANCE_MESSAGE_TX_INTERVAL_MS))
+			{
+				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::SendGuidanceSystemCommand));
+				guidanceSystemCommandTransmitTimestamp_ms = SystemTiming::get_timestamp_ms();
+			}
+			txFlags.process_all_flags();
+		}
 	}
 
 	void GuidanceInterface::process_flags(std::uint32_t flag, void *parentPointer)
@@ -79,6 +305,18 @@ namespace isobus
 
 			switch (flag)
 			{
+				case static_cast<std::uint32_t>(TransmitFlags::SendGuidanceMachineInfo):
+				{
+					transmitSuccessful = targetInterface->send_agricultural_guidance_machine_info();
+				}
+				break;
+
+				case static_cast<std::uint32_t>(TransmitFlags::SendGuidanceSystemCommand):
+				{
+					transmitSuccessful = targetInterface->send_guidance_system_command();
+				}
+				break;
+
 				default:
 					break;
 			}
@@ -87,6 +325,28 @@ namespace isobus
 			{
 				targetInterface->txFlags.set_flag(flag);
 			}
+		}
+	}
+
+	void GuidanceInterface::process_rx_message(CANMessage *message, void *parentPointer)
+	{
+		assert(nullptr != message);
+		assert(nullptr != parentPointer);
+
+		switch (message->get_identifier().get_parameter_group_number())
+		{
+			case static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceSystemCommand):
+			{
+			}
+			break;
+
+			case static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceMachineInfo):
+			{
+			}
+			break;
+
+			default:
+				break;
 		}
 	}
 } // namespace isobus

--- a/isobus/src/isobus_guidance_interface.cpp
+++ b/isobus/src/isobus_guidance_interface.cpp
@@ -32,14 +32,14 @@
 
 namespace isobus
 {
-	GuidanceInterface::GuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination) :
+	AgriculturalGuidanceInterface::AgriculturalGuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination) :
 	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberOfFlags), process_flags, this),
 	  sourceControlFunction(source),
 	  destinationControlFunction(destination)
 	{
 	}
 
-	GuidanceInterface::~GuidanceInterface()
+	AgriculturalGuidanceInterface::~AgriculturalGuidanceInterface()
 	{
 		if (initialized)
 		{
@@ -48,147 +48,197 @@ namespace isobus
 		}
 	}
 
-	void GuidanceInterface::GuidanceSystemCommand::set_status(CurvatureCommandStatus newStatus)
+	bool AgriculturalGuidanceInterface::GuidanceSystemCommand::set_status(CurvatureCommandStatus newStatus)
 	{
-		commandedStatus = newStatus;
+		if (commandedStatus != newStatus)
+		{
+			commandedStatus = newStatus;
+			return true;
+		}
+		return false;
 	}
 
-	GuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus GuidanceInterface::GuidanceSystemCommand::get_status() const
+	AgriculturalGuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus AgriculturalGuidanceInterface::GuidanceSystemCommand::get_status() const
 	{
 		return commandedStatus;
 	}
 
-	void GuidanceInterface::GuidanceSystemCommand::set_curvature(float curvature)
+	bool AgriculturalGuidanceInterface::GuidanceSystemCommand::set_curvature(float curvature)
 	{
-		commandedCurvature = curvature;
+		if (fabs(commandedCurvature - curvature) > std::numeric_limits<float>::epsilon())
+		{
+			commandedCurvature = curvature;
+			return true;
+		}
+		return false;
 	}
 
-	float GuidanceInterface::GuidanceSystemCommand::get_curvature() const
+	float AgriculturalGuidanceInterface::GuidanceSystemCommand::get_curvature() const
 	{
 		return commandedCurvature;
 	}
 
-	void GuidanceInterface::GuidanceSystemCommand::set_sender_control_function(ControlFunction *sender)
+	void AgriculturalGuidanceInterface::GuidanceSystemCommand::set_sender_control_function(ControlFunction *sender)
 	{
 		controlFunction = sender;
 	}
 
-	ControlFunction *GuidanceInterface::GuidanceSystemCommand::get_sender_control_function() const
+	ControlFunction *AgriculturalGuidanceInterface::GuidanceSystemCommand::get_sender_control_function() const
 	{
 		return controlFunction;
 	}
 
-	void GuidanceInterface::GuidanceSystemCommand::set_timestamp_ms(std::uint32_t timestamp)
+	void AgriculturalGuidanceInterface::GuidanceSystemCommand::set_timestamp_ms(std::uint32_t timestamp)
 	{
 		timestamp_ms = timestamp;
 	}
 
-	std::uint32_t GuidanceInterface::GuidanceSystemCommand::get_timestamp_ms() const
+	std::uint32_t AgriculturalGuidanceInterface::GuidanceSystemCommand::get_timestamp_ms() const
 	{
 		return timestamp_ms;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_estimated_curvature(float curvature)
+	bool AgriculturalGuidanceInterface::GuidanceMachineInfo::set_estimated_curvature(float curvature)
 	{
-		estimatedCurvature = curvature;
+		if (fabs(estimatedCurvature - curvature) > std::numeric_limits<float>::epsilon())
+		{
+			estimatedCurvature = curvature;
+			return true;
+		}
+		return false;
 	}
 
-	float GuidanceInterface::AgriculturalGuidanceMachineInfo::get_estimated_curvature() const
+	float AgriculturalGuidanceInterface::GuidanceMachineInfo::get_estimated_curvature() const
 	{
 		return estimatedCurvature;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_mechanical_system_lockout_state(MechanicalSystemLockout state)
+	bool AgriculturalGuidanceInterface::GuidanceMachineInfo::set_mechanical_system_lockout_state(MechanicalSystemLockout state)
 	{
-		mechanicalSystemLockoutState = state;
+		if (mechanicalSystemLockoutState != state)
+		{
+			mechanicalSystemLockoutState = state;
+			return true;
+		}
+		return false;
 	}
 
-	GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout GuidanceInterface::AgriculturalGuidanceMachineInfo::get_mechanical_system_lockout() const
+	AgriculturalGuidanceInterface::GuidanceMachineInfo::MechanicalSystemLockout AgriculturalGuidanceInterface::GuidanceMachineInfo::get_mechanical_system_lockout() const
 	{
 		return mechanicalSystemLockoutState;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_steering_system_readiness_state(GenericSAEbs02SlotValue state)
+	bool AgriculturalGuidanceInterface::GuidanceMachineInfo::set_guidance_steering_system_readiness_state(GenericSAEbs02SlotValue state)
 	{
-		guidanceSteeringSystemReadinessState = state;
+		if (guidanceSteeringSystemReadinessState != state)
+		{
+			guidanceSteeringSystemReadinessState = state;
+			return true;
+		}
+		return false;
 	}
 
-	GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_steering_system_readiness_state() const
+	AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue AgriculturalGuidanceInterface::GuidanceMachineInfo::get_guidance_steering_system_readiness_state() const
 	{
 		return guidanceSteeringSystemReadinessState;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_steering_input_position_status(GenericSAEbs02SlotValue state)
+	bool AgriculturalGuidanceInterface::GuidanceMachineInfo::set_guidance_steering_input_position_status(GenericSAEbs02SlotValue state)
 	{
-		guidanceSteeringInputPositionStatus = state;
+		if (guidanceSteeringInputPositionStatus != state)
+		{
+			guidanceSteeringInputPositionStatus = state;
+			return true;
+		}
+		return false;
 	}
 
-	GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_steering_input_position_status() const
+	AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue AgriculturalGuidanceInterface::GuidanceMachineInfo::get_guidance_steering_input_position_status() const
 	{
 		return guidanceSteeringInputPositionStatus;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_request_reset_command_status(RequestResetCommandStatus state)
+	bool AgriculturalGuidanceInterface::GuidanceMachineInfo::set_request_reset_command_status(RequestResetCommandStatus state)
 	{
-		requestResetCommandStatus = state;
+		if (requestResetCommandStatus != state)
+		{
+			requestResetCommandStatus = state;
+			return true;
+		}
+		return false;
 	}
 
-	GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus GuidanceInterface::AgriculturalGuidanceMachineInfo::get_request_reset_command_status() const
+	AgriculturalGuidanceInterface::GuidanceMachineInfo::RequestResetCommandStatus AgriculturalGuidanceInterface::GuidanceMachineInfo::get_request_reset_command_status() const
 	{
 		return requestResetCommandStatus;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_limit_status(GuidanceLimitStatus status)
+	bool AgriculturalGuidanceInterface::GuidanceMachineInfo::set_guidance_limit_status(GuidanceLimitStatus status)
 	{
-		guidanceLimitStatus = status;
+		if (guidanceLimitStatus != status)
+		{
+			guidanceLimitStatus = status;
+			return true;
+		}
+		return false;
 	}
 
-	GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_limit_status() const
+	AgriculturalGuidanceInterface::GuidanceMachineInfo::GuidanceLimitStatus AgriculturalGuidanceInterface::GuidanceMachineInfo::get_guidance_limit_status() const
 	{
 		return guidanceLimitStatus;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_system_command_exit_reason_code(std::uint8_t exitCode)
+	bool AgriculturalGuidanceInterface::GuidanceMachineInfo::set_guidance_system_command_exit_reason_code(std::uint8_t exitCode)
 	{
-		guidanceSystemCommandExitReasonCode = exitCode;
+		if (guidanceSystemCommandExitReasonCode != exitCode)
+		{
+			guidanceSystemCommandExitReasonCode = exitCode;
+			return true;
+		}
+		return false;
 	}
 
-	std::uint8_t GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_system_command_exit_reason_code() const
+	std::uint8_t AgriculturalGuidanceInterface::GuidanceMachineInfo::get_guidance_system_command_exit_reason_code() const
 	{
 		return guidanceSystemCommandExitReasonCode;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_guidance_system_remote_engage_switch_status(GenericSAEbs02SlotValue switchStatus)
+	bool AgriculturalGuidanceInterface::GuidanceMachineInfo::set_guidance_system_remote_engage_switch_status(GenericSAEbs02SlotValue switchStatus)
 	{
-		guidanceSystemRemoteEngageSwitchStatus = switchStatus;
+		if (guidanceSystemRemoteEngageSwitchStatus != switchStatus)
+		{
+			guidanceSystemRemoteEngageSwitchStatus = switchStatus;
+			return true;
+		}
+		return false;
 	}
 
-	GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue GuidanceInterface::AgriculturalGuidanceMachineInfo::get_guidance_system_remote_engage_switch_status() const
+	AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue AgriculturalGuidanceInterface::GuidanceMachineInfo::get_guidance_system_remote_engage_switch_status() const
 	{
 		return guidanceSystemRemoteEngageSwitchStatus;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_sender_control_function(ControlFunction *sender)
+	void AgriculturalGuidanceInterface::GuidanceMachineInfo::set_sender_control_function(ControlFunction *sender)
 	{
 		controlFunction = sender;
 	}
 
-	ControlFunction *GuidanceInterface::AgriculturalGuidanceMachineInfo::get_sender_control_function() const
+	ControlFunction *AgriculturalGuidanceInterface::GuidanceMachineInfo::get_sender_control_function() const
 	{
 		return controlFunction;
 	}
 
-	void GuidanceInterface::AgriculturalGuidanceMachineInfo::set_timestamp_ms(std::uint32_t timestamp)
+	void AgriculturalGuidanceInterface::GuidanceMachineInfo::set_timestamp_ms(std::uint32_t timestamp)
 	{
 		timestamp_ms = timestamp;
 	}
 
-	std::uint32_t GuidanceInterface::AgriculturalGuidanceMachineInfo::get_timestamp_ms() const
+	std::uint32_t AgriculturalGuidanceInterface::GuidanceMachineInfo::get_timestamp_ms() const
 	{
 		return timestamp_ms;
 	}
 
-	void GuidanceInterface::initialize()
+	void AgriculturalGuidanceInterface::initialize()
 	{
 		if (!initialized)
 		{
@@ -202,42 +252,42 @@ namespace isobus
 
 			if (nullptr != sourceControlFunction)
 			{
-				agriculturalGuidanceMachineInfoTransmitData.set_sender_control_function(sourceControlFunction.get());
+				guidanceMachineInfoTransmitData.set_sender_control_function(sourceControlFunction.get());
 				guidanceSystemCommandTransmitData.set_sender_control_function(sourceControlFunction.get());
 			}
 			initialized = true;
 		}
 	}
 
-	bool GuidanceInterface::get_initialized() const
+	bool AgriculturalGuidanceInterface::get_initialized() const
 	{
 		return initialized;
 	}
 
-	std::size_t GuidanceInterface::get_number_received_guidance_system_command_sources() const
+	std::size_t AgriculturalGuidanceInterface::get_number_received_guidance_system_command_sources() const
 	{
 		return receivedGuidanceSystemCommandMessages.size();
 	}
 
-	std::size_t GuidanceInterface::get_number_received_agricultural_guidance_machine_info_message_sources() const
+	std::size_t AgriculturalGuidanceInterface::get_number_received_guidance_machine_info_message_sources() const
 	{
-		return receivedAgriculturalGuidanceMachineInfoMessages.size();
+		return receivedGuidanceMachineInfoMessages.size();
 	}
 
-	std::shared_ptr<GuidanceInterface::AgriculturalGuidanceMachineInfo> GuidanceInterface::get_received_agricultural_guidance_machine_info(std::size_t index)
+	std::shared_ptr<AgriculturalGuidanceInterface::GuidanceMachineInfo> AgriculturalGuidanceInterface::get_received_guidance_machine_info(std::size_t index)
 	{
-		std::shared_ptr<GuidanceInterface::AgriculturalGuidanceMachineInfo> retVal = nullptr;
+		std::shared_ptr<AgriculturalGuidanceInterface::GuidanceMachineInfo> retVal = nullptr;
 
-		if (index < receivedAgriculturalGuidanceMachineInfoMessages.size())
+		if (index < receivedGuidanceMachineInfoMessages.size())
 		{
-			retVal = receivedAgriculturalGuidanceMachineInfoMessages.at(index);
+			retVal = receivedGuidanceMachineInfoMessages.at(index);
 		}
 		return retVal;
 	}
 
-	std::shared_ptr<GuidanceInterface::GuidanceSystemCommand> GuidanceInterface::get_received_guidance_system_command(std::size_t index)
+	std::shared_ptr<AgriculturalGuidanceInterface::GuidanceSystemCommand> AgriculturalGuidanceInterface::get_received_guidance_system_command(std::size_t index)
 	{
-		std::shared_ptr<GuidanceInterface::GuidanceSystemCommand> retVal = nullptr;
+		std::shared_ptr<AgriculturalGuidanceInterface::GuidanceSystemCommand> retVal = nullptr;
 
 		if (index < receivedGuidanceSystemCommandMessages.size())
 		{
@@ -246,17 +296,17 @@ namespace isobus
 		return retVal;
 	}
 
-	EventDispatcher<const std::shared_ptr<GuidanceInterface::AgriculturalGuidanceMachineInfo>> &GuidanceInterface::get_agricultural_guidance_machine_info_event_publisher()
+	EventDispatcher<const std::shared_ptr<AgriculturalGuidanceInterface::GuidanceMachineInfo>, bool> &AgriculturalGuidanceInterface::get_guidance_machine_info_event_publisher()
 	{
-		return agriculturalGuidanceMachineInfoEventPublisher;
+		return guidanceMachineInfoEventPublisher;
 	}
 
-	EventDispatcher<const std::shared_ptr<GuidanceInterface::GuidanceSystemCommand>> &GuidanceInterface::get_guidance_guidance_system_command_event_publisher()
+	EventDispatcher<const std::shared_ptr<AgriculturalGuidanceInterface::GuidanceSystemCommand>, bool> &AgriculturalGuidanceInterface::get_guidance_system_command_event_publisher()
 	{
 		return guidanceSystemCommandEventPublisher;
 	}
 
-	bool GuidanceInterface::send_guidance_system_command() const
+	bool AgriculturalGuidanceInterface::send_guidance_system_command() const
 	{
 		bool retVal = false;
 
@@ -265,7 +315,7 @@ namespace isobus
 			float scaledCurvature = std::roundf(4 * ((guidanceSystemCommandTransmitData.get_curvature() + CURVATURE_COMMAND_OFFSET_INVERSE_KM) / CURVATURE_COMMAND_RESOLUTION_PER_BIT)) / 4.0f;
 			std::uint16_t encodedCurvature = ZERO_CURVATURE_INVERSE_KM;
 
-			if (agriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature() > CURVATURE_COMMAND_MAX_INVERSE_KM)
+			if (guidanceMachineInfoTransmitData.get_estimated_curvature() > CURVATURE_COMMAND_MAX_INVERSE_KM)
 			{
 				encodedCurvature = 32127 + ZERO_CURVATURE_INVERSE_KM; // Clamp to maximum value
 				CANStackLogger::warn("[Guidance]: Transmitting a commanded curvature clamped to maximum value. Verify guidance calculations are accurate!");
@@ -299,16 +349,16 @@ namespace isobus
 		return retVal;
 	}
 
-	bool GuidanceInterface::send_agricultural_guidance_machine_info() const
+	bool AgriculturalGuidanceInterface::send_guidance_machine_info() const
 	{
 		bool retVal = false;
 
 		if (nullptr != sourceControlFunction)
 		{
-			float scaledCurvature = std::roundf(4 * ((agriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature() + CURVATURE_COMMAND_OFFSET_INVERSE_KM) / CURVATURE_COMMAND_RESOLUTION_PER_BIT)) / 4.0f;
+			float scaledCurvature = std::roundf(4 * ((guidanceMachineInfoTransmitData.get_estimated_curvature() + CURVATURE_COMMAND_OFFSET_INVERSE_KM) / CURVATURE_COMMAND_RESOLUTION_PER_BIT)) / 4.0f;
 			std::uint16_t encodedCurvature = ZERO_CURVATURE_INVERSE_KM;
 
-			if (agriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature() > CURVATURE_COMMAND_MAX_INVERSE_KM)
+			if (guidanceMachineInfoTransmitData.get_estimated_curvature() > CURVATURE_COMMAND_MAX_INVERSE_KM)
 			{
 				encodedCurvature = 32127 + ZERO_CURVATURE_INVERSE_KM; // Clamp to maximum value
 				CANStackLogger::warn("[Guidance]: Transmitting an estimated curvature clamped to maximum value. Verify guidance calculations are accurate!");
@@ -326,13 +376,13 @@ namespace isobus
 			std::array<std::uint8_t, CAN_DATA_LENGTH> buffer = {
 				static_cast<std::uint8_t>(encodedCurvature & 0xFF),
 				static_cast<std::uint8_t>((encodedCurvature >> 8) & 0xFF),
-				static_cast<std::uint8_t>((static_cast<std::uint8_t>(agriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout()) & 0x03) |
-				                          ((static_cast<std::uint8_t>(agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state()) & 0x03) << 2) |
-				                          ((static_cast<std::uint8_t>(agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status()) & 0x03) << 4) |
-				                          ((static_cast<std::uint8_t>(agriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status()) & 0x03) << 6)),
-				static_cast<std::uint8_t>(static_cast<std::uint8_t>(agriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status()) << 5),
-				static_cast<std::uint8_t>((agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code() & 0x3F) |
-				                          (static_cast<std::uint8_t>(agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status()) << 6)),
+				static_cast<std::uint8_t>((static_cast<std::uint8_t>(guidanceMachineInfoTransmitData.get_mechanical_system_lockout()) & 0x03) |
+				                          ((static_cast<std::uint8_t>(guidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state()) & 0x03) << 2) |
+				                          ((static_cast<std::uint8_t>(guidanceMachineInfoTransmitData.get_guidance_steering_input_position_status()) & 0x03) << 4) |
+				                          ((static_cast<std::uint8_t>(guidanceMachineInfoTransmitData.get_request_reset_command_status()) & 0x03) << 6)),
+				static_cast<std::uint8_t>(static_cast<std::uint8_t>(guidanceMachineInfoTransmitData.get_guidance_limit_status()) << 5),
+				static_cast<std::uint8_t>((guidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code() & 0x3F) |
+				                          (static_cast<std::uint8_t>(guidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status()) << 6)),
 				0xFF, // Reserved
 				0xFF, // Reserved
 				0xFF // Reserved
@@ -348,24 +398,28 @@ namespace isobus
 		return retVal;
 	}
 
-	void GuidanceInterface::update()
+	void AgriculturalGuidanceInterface::update()
 	{
 		if (initialized)
 		{
-			receivedAgriculturalGuidanceMachineInfoMessages.erase(std::remove_if(receivedAgriculturalGuidanceMachineInfoMessages.begin(),
-			                                                                     receivedAgriculturalGuidanceMachineInfoMessages.end(),
-			                                                                     [](std::shared_ptr<AgriculturalGuidanceMachineInfo> guidanceInfo) { return SystemTiming::time_expired_ms(guidanceInfo->get_timestamp_ms(), GUIDANCE_MESSAGE_TIMEOUT_MS); }),
-			                                                      receivedAgriculturalGuidanceMachineInfoMessages.end());
+			receivedGuidanceMachineInfoMessages.erase(std::remove_if(receivedGuidanceMachineInfoMessages.begin(),
+			                                                         receivedGuidanceMachineInfoMessages.end(),
+			                                                         [](std::shared_ptr<GuidanceMachineInfo> guidanceInfo) {
+				                                                         return SystemTiming::time_expired_ms(guidanceInfo->get_timestamp_ms(), GUIDANCE_MESSAGE_TIMEOUT_MS);
+			                                                         }),
+			                                          receivedGuidanceMachineInfoMessages.end());
 			receivedGuidanceSystemCommandMessages.erase(std::remove_if(receivedGuidanceSystemCommandMessages.begin(),
 			                                                           receivedGuidanceSystemCommandMessages.end(),
-			                                                           [](std::shared_ptr<GuidanceSystemCommand> guidanceCommand) { return SystemTiming::time_expired_ms(guidanceCommand->get_timestamp_ms(), GUIDANCE_MESSAGE_TIMEOUT_MS); }),
+			                                                           [](std::shared_ptr<GuidanceSystemCommand> guidanceCommand) {
+				                                                           return SystemTiming::time_expired_ms(guidanceCommand->get_timestamp_ms(), GUIDANCE_MESSAGE_TIMEOUT_MS);
+			                                                           }),
 			                                            receivedGuidanceSystemCommandMessages.end());
 			if (nullptr != sourceControlFunction)
 			{
-				if (SystemTiming::time_expired_ms(agriculturalGuidanceMachineInfoTransmitTimestamp_ms, GUIDANCE_MESSAGE_TX_INTERVAL_MS))
+				if (SystemTiming::time_expired_ms(guidanceMachineInfoTransmitTimestamp_ms, GUIDANCE_MESSAGE_TX_INTERVAL_MS))
 				{
 					txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::SendGuidanceMachineInfo));
-					agriculturalGuidanceMachineInfoTransmitTimestamp_ms = SystemTiming::get_timestamp_ms();
+					guidanceMachineInfoTransmitTimestamp_ms = SystemTiming::get_timestamp_ms();
 				}
 				if (SystemTiming::time_expired_ms(guidanceSystemCommandTransmitTimestamp_ms, GUIDANCE_MESSAGE_TX_INTERVAL_MS))
 				{
@@ -381,18 +435,18 @@ namespace isobus
 		}
 	}
 
-	void GuidanceInterface::process_flags(std::uint32_t flag, void *parentPointer)
+	void AgriculturalGuidanceInterface::process_flags(std::uint32_t flag, void *parentPointer)
 	{
 		if (nullptr != parentPointer)
 		{
-			auto targetInterface = static_cast<GuidanceInterface *>(parentPointer);
+			auto targetInterface = static_cast<AgriculturalGuidanceInterface *>(parentPointer);
 			bool transmitSuccessful = false;
 
 			switch (flag)
 			{
 				case static_cast<std::uint32_t>(TransmitFlags::SendGuidanceMachineInfo):
 				{
-					transmitSuccessful = targetInterface->send_agricultural_guidance_machine_info();
+					transmitSuccessful = targetInterface->send_guidance_machine_info();
 				}
 				break;
 
@@ -413,11 +467,11 @@ namespace isobus
 		}
 	}
 
-	void GuidanceInterface::process_rx_message(CANMessage *message, void *parentPointer)
+	void AgriculturalGuidanceInterface::process_rx_message(CANMessage *message, void *parentPointer)
 	{
 		assert(nullptr != message);
 		assert(nullptr != parentPointer);
-		auto targetInterface = static_cast<GuidanceInterface *>(parentPointer);
+		auto targetInterface = static_cast<AgriculturalGuidanceInterface *>(parentPointer);
 
 		switch (message->get_identifier().get_parameter_group_number())
 		{
@@ -425,25 +479,30 @@ namespace isobus
 			{
 				if (CAN_DATA_LENGTH == message->get_data_length())
 				{
-					bool lFoundExisting = false;
-
-					for (const auto &receivedCommand : targetInterface->receivedGuidanceSystemCommandMessages)
+					if (message->get_source_control_function() != nullptr)
 					{
-						if ((nullptr != receivedCommand) &&
-						    (receivedCommand->get_sender_control_function() == message->get_source_control_function()))
+						auto result = std::find_if(targetInterface->receivedGuidanceSystemCommandMessages.begin(),
+						                           targetInterface->receivedGuidanceSystemCommandMessages.end(),
+						                           [&message](const std::shared_ptr<GuidanceSystemCommand> &receivedCommand) {
+							                           return (nullptr != receivedCommand) && (receivedCommand->get_sender_control_function() == message->get_source_control_function());
+						                           });
+
+						if (result == targetInterface->receivedGuidanceSystemCommandMessages.end())
 						{
-							lFoundExisting = true;
-							parse_agricultural_guidance_system_command_message(message, receivedCommand);
-							targetInterface->guidanceSystemCommandEventPublisher.invoke(std::move(receivedCommand));
+							// There is no existing message object from this control function, so create a new one
+							targetInterface->receivedGuidanceSystemCommandMessages.push_back(std::make_shared<GuidanceSystemCommand>());
+							result = targetInterface->receivedGuidanceSystemCommandMessages.end() - 1;
+							(*result)->set_sender_control_function(message->get_source_control_function());
 						}
-					}
 
-					if ((!lFoundExisting) && (nullptr != message->get_source_control_function()))
-					{
-						auto newInfoData = std::make_shared<GuidanceSystemCommand>();
-						parse_agricultural_guidance_system_command_message(message, newInfoData);
-						targetInterface->receivedGuidanceSystemCommandMessages.push_back(newInfoData);
-						targetInterface->guidanceSystemCommandEventPublisher.invoke(std::move(newInfoData));
+						auto &guidanceCommand = *result;
+						bool changed = false;
+
+						changed |= guidanceCommand->set_curvature((message->get_uint16_at(0) * CURVATURE_COMMAND_RESOLUTION_PER_BIT) - CURVATURE_COMMAND_OFFSET_INVERSE_KM);
+						changed |= guidanceCommand->set_status(static_cast<GuidanceSystemCommand::CurvatureCommandStatus>(message->get_uint8_at(2) & 0x03));
+						guidanceCommand->set_timestamp_ms(SystemTiming::get_timestamp_ms());
+
+						targetInterface->guidanceSystemCommandEventPublisher.invoke(std::move(guidanceCommand), std::move(changed));
 					}
 				}
 				else
@@ -457,25 +516,36 @@ namespace isobus
 			{
 				if (CAN_DATA_LENGTH == message->get_data_length())
 				{
-					bool lFoundExisting = false;
-
-					for (const auto &receivedInfo : targetInterface->receivedAgriculturalGuidanceMachineInfoMessages)
+					if (message->get_source_control_function() != nullptr)
 					{
-						if ((nullptr != receivedInfo) &&
-						    (receivedInfo->get_sender_control_function() == message->get_source_control_function()))
+						auto result = std::find_if(targetInterface->receivedGuidanceMachineInfoMessages.cbegin(),
+						                           targetInterface->receivedGuidanceMachineInfoMessages.cend(),
+						                           [&message](const std::shared_ptr<GuidanceMachineInfo> &receivedInfo) {
+							                           return (nullptr != receivedInfo) && (receivedInfo->get_sender_control_function() == message->get_source_control_function());
+						                           });
+
+						if (result == targetInterface->receivedGuidanceMachineInfoMessages.cend())
 						{
-							lFoundExisting = true;
-							parse_agricultural_guidance_machine_info_message(message, receivedInfo);
-							targetInterface->agriculturalGuidanceMachineInfoEventPublisher.invoke(std::move(receivedInfo));
+							// There is no existing message object from this control function, so create a new one
+							targetInterface->receivedGuidanceMachineInfoMessages.push_back(std::make_shared<GuidanceMachineInfo>());
+							result = targetInterface->receivedGuidanceMachineInfoMessages.cend() - 1;
+							(*result)->set_sender_control_function(message->get_source_control_function());
 						}
-					}
 
-					if ((!lFoundExisting) && (nullptr != message->get_source_control_function()))
-					{
-						auto newInfoData = std::make_shared<AgriculturalGuidanceMachineInfo>();
-						parse_agricultural_guidance_machine_info_message(message, newInfoData);
-						targetInterface->receivedAgriculturalGuidanceMachineInfoMessages.push_back(newInfoData);
-						targetInterface->agriculturalGuidanceMachineInfoEventPublisher.invoke(std::move(newInfoData));
+						auto &machineInfo = *result;
+						bool changed = false;
+
+						changed |= machineInfo->set_estimated_curvature((message->get_uint16_at(0) * CURVATURE_COMMAND_RESOLUTION_PER_BIT) - CURVATURE_COMMAND_OFFSET_INVERSE_KM);
+						changed |= machineInfo->set_mechanical_system_lockout_state(static_cast<GuidanceMachineInfo::MechanicalSystemLockout>(message->get_uint8_at(2) & 0x03));
+						changed |= machineInfo->set_guidance_steering_system_readiness_state(static_cast<GuidanceMachineInfo::GenericSAEbs02SlotValue>((message->get_uint8_at(2) >> 2) & 0x03));
+						changed |= machineInfo->set_guidance_steering_input_position_status(static_cast<GuidanceMachineInfo::GenericSAEbs02SlotValue>((message->get_uint8_at(2) >> 4) & 0x03));
+						changed |= machineInfo->set_request_reset_command_status(static_cast<GuidanceMachineInfo::RequestResetCommandStatus>((message->get_uint8_at(2) >> 6) & 0x03));
+						changed |= machineInfo->set_guidance_limit_status(static_cast<GuidanceMachineInfo::GuidanceLimitStatus>(message->get_uint8_at(3) >> 5));
+						changed |= machineInfo->set_guidance_system_command_exit_reason_code(message->get_uint8_at(4) & 0x3F);
+						changed |= machineInfo->set_guidance_system_remote_engage_switch_status(static_cast<GuidanceMachineInfo::GenericSAEbs02SlotValue>((message->get_uint8_at(4) >> 6) & 0x03));
+						machineInfo->set_timestamp_ms(SystemTiming::get_timestamp_ms());
+
+						targetInterface->guidanceMachineInfoEventPublisher.invoke(std::move(*result), std::move(changed));
 					}
 				}
 				else
@@ -488,39 +558,5 @@ namespace isobus
 			default:
 				break;
 		}
-	}
-
-	void GuidanceInterface::parse_agricultural_guidance_machine_info_message(CANMessage *message, std::shared_ptr<AgriculturalGuidanceMachineInfo> machineInfo)
-	{
-		// These should never happen based on how the interface is using it, but sanity check anyways
-		assert(nullptr != machineInfo);
-		assert(nullptr != message);
-		assert(CAN_DATA_LENGTH == message->get_data_length());
-
-		const auto &data = message->get_data();
-		machineInfo->set_sender_control_function(message->get_source_control_function());
-		machineInfo->set_estimated_curvature((message->get_uint16_at(0) * CURVATURE_COMMAND_RESOLUTION_PER_BIT) - CURVATURE_COMMAND_OFFSET_INVERSE_KM);
-		machineInfo->set_mechanical_system_lockout_state(static_cast<AgriculturalGuidanceMachineInfo::MechanicalSystemLockout>(data[2] & 0x03));
-		machineInfo->set_guidance_steering_system_readiness_state(static_cast<AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue>((data[2] >> 2) & 0x03));
-		machineInfo->set_guidance_steering_input_position_status(static_cast<AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue>((data[2] >> 4) & 0x03));
-		machineInfo->set_request_reset_command_status(static_cast<AgriculturalGuidanceMachineInfo::RequestResetCommandStatus>((data[2] >> 6) & 0x03));
-		machineInfo->set_guidance_limit_status(static_cast<AgriculturalGuidanceMachineInfo::GuidanceLimitStatus>(data[3] >> 5));
-		machineInfo->set_guidance_system_command_exit_reason_code(data[4] & 0x3F);
-		machineInfo->set_guidance_system_remote_engage_switch_status(static_cast<AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue>((data[4] >> 6) & 0x03));
-		machineInfo->set_timestamp_ms(SystemTiming::get_timestamp_ms());
-	}
-
-	void GuidanceInterface::parse_agricultural_guidance_system_command_message(CANMessage *message, std::shared_ptr<GuidanceSystemCommand> guidanceCommand)
-	{
-		// These should never happen based on how the interface is using it, but sanity check anyways
-		assert(nullptr != guidanceCommand);
-		assert(nullptr != message);
-		assert(CAN_DATA_LENGTH == message->get_data_length());
-
-		const auto &data = message->get_data();
-		guidanceCommand->set_sender_control_function(message->get_source_control_function());
-		guidanceCommand->set_curvature((message->get_uint16_at(0) * CURVATURE_COMMAND_RESOLUTION_PER_BIT) - CURVATURE_COMMAND_OFFSET_INVERSE_KM);
-		guidanceCommand->set_status(static_cast<GuidanceSystemCommand::CurvatureCommandStatus>(data.at(2) & 0x03));
-		guidanceCommand->set_timestamp_ms(SystemTiming::get_timestamp_ms());
 	}
 } // namespace isobus

--- a/test/guidance_tests.cpp
+++ b/test/guidance_tests.cpp
@@ -10,11 +10,11 @@
 
 using namespace isobus;
 
-class TestGuidanceInterface : public GuidanceInterface
+class TestGuidanceInterface : public AgriculturalGuidanceInterface
 {
 public:
 	TestGuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination) :
-	  GuidanceInterface(source, destination){
+	  AgriculturalGuidanceInterface(source, destination){
 
 	  };
 
@@ -30,15 +30,15 @@ public:
 
 	bool test_wrapper_send_guidance_info() const
 	{
-		return send_agricultural_guidance_machine_info();
+		return send_guidance_machine_info();
 	}
 
-	static void test_guidance_system_command_callback(const std::shared_ptr<GuidanceSystemCommand>)
+	static void test_guidance_system_command_callback(const std::shared_ptr<GuidanceSystemCommand>, bool)
 	{
 		wasGuidanceSystemCommandCallbackHit = true;
 	}
 
-	static void test_guidance_info_callback(const std::shared_ptr<AgriculturalGuidanceMachineInfo>)
+	static void test_guidance_info_callback(const std::shared_ptr<GuidanceMachineInfo>, bool)
 	{
 		wasGuidanceInfoCallbackHit = true;
 	}
@@ -100,51 +100,51 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 	TestGuidanceInterface interfaceUnderTest(testECU, nullptr); // Configured for broadcasts
 
 	// Test fresh state
-	EXPECT_EQ(0, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());
 	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_system_command_sources());
-	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_guidance_machine_info(0));
 	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 	interfaceUnderTest.test_wrapper_set_flag(0);
 	interfaceUnderTest.update(); // Nothing should happen, since not initialized yet
 	EXPECT_TRUE(testPlugin.get_queue_empty());
 
-	EXPECT_EQ(0.0f, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::NotAvailable, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
-	EXPECT_EQ(static_cast<std::uint8_t>(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceSystemCommandExitReasonCode::NotAvailable), interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::NotAvailable, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotAvailable, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout());
+	EXPECT_EQ(0.0f, interfaceUnderTest.guidanceMachineInfoTransmitData.get_estimated_curvature());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GuidanceLimitStatus::NotAvailable, interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_limit_status());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
+	EXPECT_EQ(static_cast<std::uint8_t>(AgriculturalGuidanceInterface::GuidanceMachineInfo::GuidanceSystemCommandExitReasonCode::NotAvailable), interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::RequestResetCommandStatus::NotAvailable, interfaceUnderTest.guidanceMachineInfoTransmitData.get_request_reset_command_status());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::MechanicalSystemLockout::NotAvailable, interfaceUnderTest.guidanceMachineInfoTransmitData.get_mechanical_system_lockout());
 
 	interfaceUnderTest.initialize();
 	EXPECT_TRUE(interfaceUnderTest.get_initialized());
 	interfaceUnderTest.initialize();
 	EXPECT_TRUE(interfaceUnderTest.get_initialized());
 
-	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_estimated_curvature(10.0f);
-	EXPECT_NEAR(10.0f, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature(), 0.01f);
+	interfaceUnderTest.guidanceMachineInfoTransmitData.set_estimated_curvature(10.0f);
+	EXPECT_NEAR(10.0f, interfaceUnderTest.guidanceMachineInfoTransmitData.get_estimated_curvature(), 0.01f);
 
-	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_limit_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::LimitedLow);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::LimitedLow, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status());
+	interfaceUnderTest.guidanceMachineInfoTransmitData.set_guidance_limit_status(AgriculturalGuidanceInterface::GuidanceMachineInfo::GuidanceLimitStatus::LimitedLow);
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GuidanceLimitStatus::LimitedLow, interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_limit_status());
 
-	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_steering_input_position_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
+	interfaceUnderTest.guidanceMachineInfoTransmitData.set_guidance_steering_input_position_status(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive);
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive, interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
 
-	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_steering_system_readiness_state(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
+	interfaceUnderTest.guidanceMachineInfoTransmitData.set_guidance_steering_system_readiness_state(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
 
-	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_system_remote_engage_switch_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
+	interfaceUnderTest.guidanceMachineInfoTransmitData.set_guidance_system_remote_engage_switch_status(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
 
-	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_mechanical_system_lockout_state(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotActive);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotActive, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout());
+	interfaceUnderTest.guidanceMachineInfoTransmitData.set_mechanical_system_lockout_state(AgriculturalGuidanceInterface::GuidanceMachineInfo::MechanicalSystemLockout::NotActive);
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::MechanicalSystemLockout::NotActive, interfaceUnderTest.guidanceMachineInfoTransmitData.get_mechanical_system_lockout());
 
-	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_request_reset_command_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status());
+	interfaceUnderTest.guidanceMachineInfoTransmitData.set_request_reset_command_status(AgriculturalGuidanceInterface::GuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired);
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired, interfaceUnderTest.guidanceMachineInfoTransmitData.get_request_reset_command_status());
 
-	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_system_command_exit_reason_code(27);
-	EXPECT_EQ(27, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
+	interfaceUnderTest.guidanceMachineInfoTransmitData.set_guidance_system_command_exit_reason_code(27);
+	EXPECT_EQ(27, interfaceUnderTest.guidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
 
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_info());
 	ASSERT_TRUE(testPlugin.read_frame(testFrame));
@@ -171,9 +171,9 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 
 	// Test the command message next. It's much simpler.
 	interfaceUnderTest.guidanceSystemCommandTransmitData.set_curvature(-43.4f);
-	interfaceUnderTest.guidanceSystemCommandTransmitData.set_status(GuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer);
+	interfaceUnderTest.guidanceSystemCommandTransmitData.set_status(AgriculturalGuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer);
 	EXPECT_NEAR(-43.5f, interfaceUnderTest.guidanceSystemCommandTransmitData.get_curvature(), 0.24f); // This also tests rounding to the nearest 0.25 km-1
-	EXPECT_EQ(GuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer, interfaceUnderTest.guidanceSystemCommandTransmitData.get_status());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer, interfaceUnderTest.guidanceSystemCommandTransmitData.get_status());
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_system_command());
 	ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -183,7 +183,7 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 
 	EXPECT_EQ(1, (testFrame.data[2] & 0x03));
 
-	EXPECT_NE(nullptr, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_sender_control_function());
+	EXPECT_NE(nullptr, interfaceUnderTest.guidanceMachineInfoTransmitData.get_sender_control_function());
 	EXPECT_NE(nullptr, interfaceUnderTest.guidanceSystemCommandTransmitData.get_sender_control_function());
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(105));
@@ -208,7 +208,7 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 
 	EXPECT_FALSE(interfaceUnderTest.test_wrapper_send_guidance_system_command());
 	EXPECT_FALSE(interfaceUnderTest.test_wrapper_send_guidance_info());
-	EXPECT_EQ(nullptr, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_sender_control_function());
+	EXPECT_EQ(nullptr, interfaceUnderTest.guidanceMachineInfoTransmitData.get_sender_control_function());
 	EXPECT_EQ(nullptr, interfaceUnderTest.guidanceSystemCommandTransmitData.get_sender_control_function());
 
 	CANNetworkManager::CANNetwork.update();
@@ -217,9 +217,9 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	interfaceUnderTest.initialize();
 	EXPECT_EQ(true, interfaceUnderTest.get_initialized());
 
-	EXPECT_EQ(0, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());
 	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_system_command_sources());
-	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_guidance_machine_info(0));
 	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 
 	// Force claim some other ECU
@@ -239,8 +239,8 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	CANNetworkManager::CANNetwork.update();
 
 	// Register callbacks to test
-	auto guidanceCommandListener = interfaceUnderTest.get_guidance_guidance_system_command_event_publisher().add_listener(TestGuidanceInterface::test_guidance_system_command_callback);
-	auto guidanceInfoListener = interfaceUnderTest.get_agricultural_guidance_machine_info_event_publisher().add_listener(TestGuidanceInterface::test_guidance_info_callback);
+	auto guidanceCommandListener = interfaceUnderTest.get_guidance_system_command_event_publisher().add_listener(TestGuidanceInterface::test_guidance_system_command_callback);
+	auto guidanceInfoListener = interfaceUnderTest.get_guidance_machine_info_event_publisher().add_listener(TestGuidanceInterface::test_guidance_info_callback);
 	EXPECT_EQ(false, TestGuidanceInterface::wasGuidanceInfoCallbackHit);
 	EXPECT_EQ(false, TestGuidanceInterface::wasGuidanceSystemCommandCallbackHit);
 
@@ -263,15 +263,15 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	EXPECT_EQ(true, TestGuidanceInterface::wasGuidanceSystemCommandCallbackHit);
 	TestGuidanceInterface::wasGuidanceSystemCommandCallbackHit = false;
 
-	EXPECT_EQ(0, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());
 	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_system_command_sources());
-	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_guidance_machine_info(0));
 	ASSERT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 
 	auto guidanceCommand = interfaceUnderTest.get_received_guidance_system_command(0);
 
 	EXPECT_NEAR(94.25, guidanceCommand->get_curvature(), 0.2f);
-	EXPECT_EQ(GuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer, guidanceCommand->get_status());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer, guidanceCommand->get_status());
 
 	// Test estimated curvature
 	testCurvature = std::roundf(4 * ((-47.75f + 8032) / 0.25f)) / 4.0f; // manually encode a curvature of -47.75 km-1
@@ -290,19 +290,19 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	EXPECT_EQ(true, TestGuidanceInterface::wasGuidanceInfoCallbackHit);
 	EXPECT_EQ(false, TestGuidanceInterface::wasGuidanceSystemCommandCallbackHit);
 
-	EXPECT_EQ(1, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());
 	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_system_command_sources());
-	EXPECT_NE(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_machine_info(0));
 	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 
-	auto estimatedCurvatureInfo = interfaceUnderTest.get_received_agricultural_guidance_machine_info(0);
+	auto estimatedCurvatureInfo = interfaceUnderTest.get_received_guidance_machine_info(0);
 	EXPECT_NEAR(estimatedCurvatureInfo->get_estimated_curvature(), -47.75f, 0.2f);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::NotAvailable, estimatedCurvatureInfo->get_guidance_limit_status());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, estimatedCurvatureInfo->get_guidance_steering_input_position_status());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, estimatedCurvatureInfo->get_guidance_steering_system_readiness_state());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, estimatedCurvatureInfo->get_guidance_system_remote_engage_switch_status());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::Active, estimatedCurvatureInfo->get_mechanical_system_lockout());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetRequired, estimatedCurvatureInfo->get_request_reset_command_status());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GuidanceLimitStatus::NotAvailable, estimatedCurvatureInfo->get_guidance_limit_status());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, estimatedCurvatureInfo->get_guidance_steering_input_position_status());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, estimatedCurvatureInfo->get_guidance_steering_system_readiness_state());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, estimatedCurvatureInfo->get_guidance_system_remote_engage_switch_status());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::MechanicalSystemLockout::Active, estimatedCurvatureInfo->get_mechanical_system_lockout());
+	EXPECT_EQ(AgriculturalGuidanceInterface::GuidanceMachineInfo::RequestResetCommandStatus::ResetRequired, estimatedCurvatureInfo->get_request_reset_command_status());
 
 	// Make a slightly different value to confirm we don't add a duplicate source
 	testCurvature = std::roundf(4 * ((-44.75f + 8032) / 0.25f)) / 4.0f; // manually encode a curvature of -47.75 km-1
@@ -318,9 +318,9 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
-	EXPECT_EQ(1, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());
 	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_system_command_sources());
-	EXPECT_NE(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_machine_info(0));
 	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 
 	// Test different commanded curvature doesn't cause duplicates
@@ -338,16 +338,16 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
-	EXPECT_EQ(1, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());
 	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_system_command_sources());
-	EXPECT_NE(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_machine_info(0));
 	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 
 	// Test timeouts
 	std::this_thread::sleep_for(std::chrono::milliseconds(200));
 	interfaceUnderTest.update();
-	EXPECT_EQ(0, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());
 	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_system_command_sources());
-	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_guidance_machine_info(0));
 	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 }

--- a/test/guidance_tests.cpp
+++ b/test/guidance_tests.cpp
@@ -6,6 +6,8 @@
 #include "isobus/isobus/isobus_guidance_interface.hpp"
 #include "isobus/utility/system_timing.hpp"
 
+#include <cmath>
+
 using namespace isobus;
 
 class TestGuidanceInterface : public GuidanceInterface
@@ -54,7 +56,13 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 
 	auto testECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x44, 0);
 
-	HardwareInterfaceCANFrame testFrame = { 0 };
+	HardwareInterfaceCANFrame testFrame;
+	testFrame.timestamp_us = 0;
+	testFrame.identifier = 0;
+	testFrame.channel = 0;
+	std::memset(testFrame.data, 0, sizeof(testFrame.data));
+	testFrame.dataLength = 0; ///< The length of the data used in the frame
+	testFrame.isExtendedFrame = true; ///< Denotes if the frame is extended format
 
 	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
 
@@ -84,38 +92,43 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 	interfaceUnderTest.update(); // Nothing should happen, since not initialized yet
 	EXPECT_TRUE(testPlugin.get_queue_empty());
 
-	EXPECT_EQ(0.0f, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::NotAvailable, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
-	EXPECT_EQ(static_cast<std::uint8_t>(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceSystemCommandExitReasonCode::NotAvailable), interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::NotAvailable, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status());
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotAvailable, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout());
+	EXPECT_EQ(0.0f, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::NotAvailable, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
+	EXPECT_EQ(static_cast<std::uint8_t>(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceSystemCommandExitReasonCode::NotAvailable), interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::NotAvailable, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotAvailable, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout());
 
-	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_estimated_curvature(10.0f);
-	EXPECT_NEAR(10.0f, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature(), 0.01f);
+	interfaceUnderTest.initialize();
+	EXPECT_TRUE(interfaceUnderTest.get_initialized());
+	interfaceUnderTest.initialize();
+	EXPECT_TRUE(interfaceUnderTest.get_initialized());
 
-	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_limit_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::LimitedLow);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::LimitedLow, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status());
+	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_estimated_curvature(10.0f);
+	EXPECT_NEAR(10.0f, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature(), 0.01f);
 
-	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_steering_input_position_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
+	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_limit_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::LimitedLow);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::LimitedLow, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status());
 
-	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_steering_system_readiness_state(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
+	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_steering_input_position_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
 
-	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_system_remote_engage_switch_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
+	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_steering_system_readiness_state(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
 
-	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_mechanical_system_lockout_state(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotActive);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotActive, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout());
+	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_system_remote_engage_switch_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
 
-	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_request_reset_command_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired);
-	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status());
+	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_mechanical_system_lockout_state(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotActive);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotActive, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout());
 
-	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_system_command_exit_reason_code(27);
-	EXPECT_EQ(27, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
+	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_request_reset_command_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status());
+
+	interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.set_guidance_system_command_exit_reason_code(27);
+	EXPECT_EQ(27, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
 
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_info());
 	ASSERT_TRUE(testPlugin.read_frame(testFrame));
@@ -141,8 +154,8 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 	EXPECT_EQ(0xFF, testFrame.data[7]);
 
 	// Test the command message next. It's much simpler.
-	interfaceUnderTest.GuidanceSystemCommandTransmitData.set_curvature(-43.4f);
-	interfaceUnderTest.GuidanceSystemCommandTransmitData.set_status(GuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer);
+	interfaceUnderTest.guidanceSystemCommandTransmitData.set_curvature(-43.4f);
+	interfaceUnderTest.guidanceSystemCommandTransmitData.set_status(GuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer);
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_system_command());
 	ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -152,6 +165,13 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 
 	EXPECT_EQ(1, (testFrame.data[2] & 0x03));
 
+	EXPECT_NE(nullptr, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_sender_control_function());
+	EXPECT_NE(nullptr, interfaceUnderTest.guidanceSystemCommandTransmitData.get_sender_control_function());
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(105));
+	interfaceUnderTest.update();
+	ASSERT_TRUE(testPlugin.read_frame(testFrame)); // Message should get sent on a 100ms interval
+
 	CANHardwareInterface::stop();
 	testPlugin.close();
 }
@@ -159,14 +179,25 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 {
 	TestGuidanceInterface interfaceUnderTest(nullptr, nullptr);
-	HardwareInterfaceCANFrame testFrame = { 0 };
+	HardwareInterfaceCANFrame testFrame;
+
+	testFrame.timestamp_us = 0;
+	testFrame.identifier = 0;
+	testFrame.channel = 0;
+	std::memset(testFrame.data, 0, sizeof(testFrame.data));
+	testFrame.dataLength = 0;
+	testFrame.isExtendedFrame = true;
 
 	EXPECT_FALSE(interfaceUnderTest.test_wrapper_send_guidance_system_command());
 	EXPECT_FALSE(interfaceUnderTest.test_wrapper_send_guidance_info());
+	EXPECT_EQ(nullptr, interfaceUnderTest.agriculturalGuidanceMachineInfoTransmitData.get_sender_control_function());
+	EXPECT_EQ(nullptr, interfaceUnderTest.guidanceSystemCommandTransmitData.get_sender_control_function());
 
 	CANNetworkManager::CANNetwork.update();
 
+	EXPECT_EQ(false, interfaceUnderTest.get_initialized());
 	interfaceUnderTest.initialize();
+	EXPECT_EQ(true, interfaceUnderTest.get_initialized());
 
 	EXPECT_EQ(0, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
 	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_system_command_sources());
@@ -189,7 +220,8 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	CANNetworkManager::process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
-	std::uint16_t testCurvature = std::roundf(4 * ((94.25 + 8032) / 0.25)) / 4.0f; // manually encode a curvature of 94.25 km-1
+	// Test commanded curvature
+	std::uint16_t testCurvature = std::roundf(4 * ((94.25f + 8032) / 0.25f)) / 4.0f; // manually encode a curvature of 94.25 km-1
 	testFrame.dataLength = 8;
 	testFrame.identifier = 0xCADFF46;
 	testFrame.data[0] = static_cast<std::uint8_t>(testCurvature & 0xFF);
@@ -206,5 +238,77 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	EXPECT_EQ(0, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
 	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_system_command_sources());
 	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	ASSERT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
+
+	auto guidanceCommand = interfaceUnderTest.get_received_guidance_system_command(0);
+
+	EXPECT_NEAR(94.25, guidanceCommand->get_curvature(), 0.2f);
+	EXPECT_EQ(GuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer, guidanceCommand->get_status());
+
+	// Test estimated curvature
+	testCurvature = std::roundf(4 * ((-47.75f + 8032) / 0.25f)) / 4.0f; // manually encode a curvature of -47.75 km-1
+	testFrame.identifier = 0xCACFF46;
+	testFrame.data[0] = static_cast<std::uint8_t>(testCurvature & 0xFF);
+	testFrame.data[1] = static_cast<std::uint8_t>((testCurvature >> 8) & 0xFF);
+	testFrame.data[2] = 0x55; // All components set to 1
+	testFrame.data[3] = (0x07 << 5); // NA
+	testFrame.data[4] = (0x24 | (1 << 6)); // Exit code 36 and 1 for engage switch
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0xFF;
+	testFrame.data[7] = 0xFF;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_system_command_sources());
+	EXPECT_NE(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
+
+	auto estimatedCurvatureInfo = interfaceUnderTest.get_received_agricultural_guidance_machine_info(0);
+	EXPECT_NEAR(estimatedCurvatureInfo->get_estimated_curvature(), -47.75f, 0.2f);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::NotAvailable, estimatedCurvatureInfo->get_guidance_limit_status());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, estimatedCurvatureInfo->get_guidance_steering_input_position_status());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, estimatedCurvatureInfo->get_guidance_steering_system_readiness_state());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, estimatedCurvatureInfo->get_guidance_system_remote_engage_switch_status());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::Active, estimatedCurvatureInfo->get_mechanical_system_lockout());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetRequired, estimatedCurvatureInfo->get_request_reset_command_status());
+
+	// Make a slightly different value to confirm we don't add a duplicate source
+	testCurvature = std::roundf(4 * ((-44.75f + 8032) / 0.25f)) / 4.0f; // manually encode a curvature of -47.75 km-1
+	testFrame.identifier = 0xCACFF46;
+	testFrame.data[0] = static_cast<std::uint8_t>(testCurvature & 0xFF);
+	testFrame.data[1] = static_cast<std::uint8_t>((testCurvature >> 8) & 0xFF);
+	testFrame.data[2] = 0x00; // All components set to 1
+	testFrame.data[3] = (0x04 << 5); // NA
+	testFrame.data[4] = (0x24 | (0 << 6)); // Exit code 36 and 1 for engage switch
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0xFF;
+	testFrame.data[7] = 0xFF;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_system_command_sources());
+	EXPECT_NE(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
+
+	// Test different commanded curvature doesn't cause duplicates
+	testCurvature = std::roundf(4 * ((99.25f + 8032) / 0.25f)) / 4.0f; // manually encode a curvature of 99.25 km-1
+	testFrame.dataLength = 8;
+	testFrame.identifier = 0xCADFF46;
+	testFrame.data[0] = static_cast<std::uint8_t>(testCurvature & 0xFF);
+	testFrame.data[1] = static_cast<std::uint8_t>((testCurvature >> 8) & 0xFF);
+	testFrame.data[2] = 0xFF;
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0xFF;
+	testFrame.data[7] = 0xFF;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_system_command_sources());
+	EXPECT_NE(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
 	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 }

--- a/test/guidance_tests.cpp
+++ b/test/guidance_tests.cpp
@@ -2,10 +2,35 @@
 
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/hardware_integration/virtual_can_plugin.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/isobus_guidance_interface.hpp"
 #include "isobus/utility/system_timing.hpp"
 
 using namespace isobus;
+
+class TestGuidanceInterface : public GuidanceInterface
+{
+public:
+	TestGuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination) :
+	  GuidanceInterface(source, destination){
+
+	  };
+
+	void test_wrapper_set_flag(std::uint32_t flag)
+	{
+		txFlags.set_flag(flag);
+	}
+
+	bool test_wrapper_send_guidance_system_command() const
+	{
+		return send_guidance_system_command();
+	}
+
+	bool test_wrapper_send_guidance_info() const
+	{
+		return send_agricultural_guidance_machine_info();
+	}
+};
 
 TEST(GUIDANCE_TESTS, GuidanceMessages)
 {
@@ -29,7 +54,7 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 
 	auto testECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x44, 0);
 
-	HardwareInterfaceCANFrame testFrame;
+	HardwareInterfaceCANFrame testFrame = { 0 };
 
 	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
 
@@ -48,16 +73,138 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 	}
 	ASSERT_TRUE(testPlugin.get_queue_empty());
 
-	GuidanceInterface interfaceUnderTest(testECU, nullptr); // Configured for broadcasts
+	TestGuidanceInterface interfaceUnderTest(testECU, nullptr); // Configured for broadcasts
+
+	// Test fresh state
+	EXPECT_EQ(0, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_system_command_sources());
+	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
+	interfaceUnderTest.test_wrapper_set_flag(0);
+	interfaceUnderTest.update(); // Nothing should happen, since not initialized yet
+	EXPECT_TRUE(testPlugin.get_queue_empty());
+
+	EXPECT_EQ(0.0f, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::NotAvailable, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
+	EXPECT_EQ(static_cast<std::uint8_t>(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceSystemCommandExitReasonCode::NotAvailable), interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::NotAvailableTakeNoAction, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::NotAvailable, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status());
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotAvailable, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout());
+
+	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_estimated_curvature(10.0f);
+	EXPECT_NEAR(10.0f, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_estimated_curvature(), 0.01f);
+
+	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_limit_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::LimitedLow);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GuidanceLimitStatus::LimitedLow, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_limit_status());
+
+	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_steering_input_position_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::DisabledOffPassive, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_input_position_status());
+
+	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_steering_system_readiness_state(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_steering_system_readiness_state());
+
+	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_system_remote_engage_switch_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::GenericSAEbs02SlotValue::EnabledOnActive, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_remote_engage_switch_status());
+
+	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_mechanical_system_lockout_state(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotActive);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::MechanicalSystemLockout::NotActive, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_mechanical_system_lockout());
+
+	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_request_reset_command_status(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired);
+	EXPECT_EQ(GuidanceInterface::AgriculturalGuidanceMachineInfo::RequestResetCommandStatus::ResetNotRequired, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_request_reset_command_status());
+
+	interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.set_guidance_system_command_exit_reason_code(27);
+	EXPECT_EQ(27, interfaceUnderTest.AgriculturalGuidanceMachineInfoTransmitData.get_guidance_system_command_exit_reason_code());
+
+	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_info());
+	ASSERT_TRUE(testPlugin.read_frame(testFrame));
+
+	// Validate message encoding
+	EXPECT_EQ(0, testFrame.channel);
+	EXPECT_EQ(8, testFrame.dataLength);
+	EXPECT_EQ(0x0CACFF44, testFrame.identifier);
+
+	std::uint16_t decodedCurvature = static_cast<std::uint16_t>(testFrame.data[0]) | (static_cast<std::uint16_t>(testFrame.data[1]) << 8);
+	float descaledCurvature = (decodedCurvature * 0.25f) - 8032.0f;
+	EXPECT_NEAR(descaledCurvature, 10.0f, 0.24f);
+
+	EXPECT_EQ(0, (testFrame.data[2] & 0x03));
+	EXPECT_EQ(1, ((testFrame.data[2] >> 2) & 0x03));
+	EXPECT_EQ(0, ((testFrame.data[2] >> 4) & 0x03));
+	EXPECT_EQ(0, ((testFrame.data[2] >> 6) & 0x03));
+	EXPECT_EQ(3, ((testFrame.data[3] >> 5) & 0x07));
+	EXPECT_EQ(27, ((testFrame.data[4]) & 0x3F));
+	EXPECT_EQ(1, ((testFrame.data[4] >> 6) & 0x03));
+	EXPECT_EQ(0xFF, testFrame.data[5]);
+	EXPECT_EQ(0xFF, testFrame.data[6]);
+	EXPECT_EQ(0xFF, testFrame.data[7]);
+
+	// Test the command message next. It's much simpler.
+	interfaceUnderTest.GuidanceSystemCommandTransmitData.set_curvature(-43.4f);
+	interfaceUnderTest.GuidanceSystemCommandTransmitData.set_status(GuidanceInterface::GuidanceSystemCommand::CurvatureCommandStatus::IntendedToSteer);
+	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_system_command());
+	ASSERT_TRUE(testPlugin.read_frame(testFrame));
+
+	decodedCurvature = static_cast<std::uint16_t>(testFrame.data[0]) | (static_cast<std::uint16_t>(testFrame.data[1]) << 8);
+	descaledCurvature = (decodedCurvature * 0.25f) - 8032.0f;
+	EXPECT_NEAR(descaledCurvature, -43.5f, 0.24f);
+
+	EXPECT_EQ(1, (testFrame.data[2] & 0x03));
 
 	CANHardwareInterface::stop();
 	testPlugin.close();
 }
 
-TEST(GUIDANCE_TESTS, ListenOnlyMode)
+TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 {
-	GuidanceInterface interfaceUnderTest(nullptr, nullptr);
+	TestGuidanceInterface interfaceUnderTest(nullptr, nullptr);
+	HardwareInterfaceCANFrame testFrame = { 0 };
 
-	EXPECT_FALSE(interfaceUnderTest.send_guidance_system_command());
-	EXPECT_FALSE(interfaceUnderTest.send_agricultural_guidance_machine_info());
+	EXPECT_FALSE(interfaceUnderTest.test_wrapper_send_guidance_system_command());
+	EXPECT_FALSE(interfaceUnderTest.test_wrapper_send_guidance_info());
+
+	CANNetworkManager::CANNetwork.update();
+
+	interfaceUnderTest.initialize();
+
+	EXPECT_EQ(0, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_system_command_sources());
+	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
+
+	// Force claim some other ECU
+	testFrame.dataLength = 8;
+	testFrame.channel = 0;
+	testFrame.isExtendedFrame = true;
+	testFrame.identifier = 0x18EEFF46;
+	testFrame.data[0] = 0x03;
+	testFrame.data[1] = 0x05;
+	testFrame.data[2] = 0x04;
+	testFrame.data[3] = 0x12;
+	testFrame.data[4] = 0x00;
+	testFrame.data[5] = 0x82;
+	testFrame.data[6] = 0x01;
+	testFrame.data[7] = 0xA0;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+
+	std::uint16_t testCurvature = std::roundf(4 * ((94.25 + 8032) / 0.25)) / 4.0f; // manually encode a curvature of 94.25 km-1
+	testFrame.dataLength = 8;
+	testFrame.identifier = 0xCADFF46;
+	testFrame.data[0] = static_cast<std::uint8_t>(testCurvature & 0xFF);
+	testFrame.data[1] = static_cast<std::uint8_t>((testCurvature >> 8) & 0xFF);
+	testFrame.data[2] = 0xFD; // Intended to steer + reserved bits set to 1
+	testFrame.data[3] = 0xFF;
+	testFrame.data[4] = 0xFF;
+	testFrame.data[5] = 0xFF;
+	testFrame.data[6] = 0xFF;
+	testFrame.data[7] = 0xFF;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.update();
+
+	EXPECT_EQ(0, interfaceUnderTest.get_number_received_agricultural_guidance_machine_info_message_sources());
+	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_system_command_sources());
+	EXPECT_EQ(nullptr, interfaceUnderTest.get_received_agricultural_guidance_machine_info(0));
+	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 }

--- a/test/guidance_tests.cpp
+++ b/test/guidance_tests.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+#include "isobus/isobus/isobus_guidance.hpp"
+
+using namespace isobus;
+
+TEST(GUIDANCE_TESTS, GuidanceMessages)
+{
+}

--- a/test/guidance_tests.cpp
+++ b/test/guidance_tests.cpp
@@ -1,9 +1,63 @@
 #include <gtest/gtest.h>
 
-#include "isobus/isobus/isobus_guidance.hpp"
+#include "isobus/hardware_integration/can_hardware_interface.hpp"
+#include "isobus/hardware_integration/virtual_can_plugin.hpp"
+#include "isobus/isobus/isobus_guidance_interface.hpp"
+#include "isobus/utility/system_timing.hpp"
 
 using namespace isobus;
 
 TEST(GUIDANCE_TESTS, GuidanceMessages)
 {
+	VirtualCANPlugin testPlugin;
+	testPlugin.open();
+
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
+	CANHardwareInterface::start();
+
+	isobus::NAME TestDeviceNAME(0);
+	TestDeviceNAME.set_arbitrary_address_capable(true);
+	TestDeviceNAME.set_industry_group(3);
+	TestDeviceNAME.set_device_class(4);
+	TestDeviceNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::AdaptiveFrontLightingSystem));
+	TestDeviceNAME.set_identity_number(2);
+	TestDeviceNAME.set_ecu_instance(4);
+	TestDeviceNAME.set_function_instance(0);
+	TestDeviceNAME.set_device_class_instance(0);
+	TestDeviceNAME.set_manufacturer_code(64);
+
+	auto testECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x44, 0);
+
+	HardwareInterfaceCANFrame testFrame;
+
+	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
+
+	while ((!testECU->get_address_valid()) &&
+	       (!SystemTiming::time_expired_ms(waitingTimestamp_ms, 2000)))
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+
+	ASSERT_TRUE(testECU->get_address_valid());
+
+	// Get the virtual CAN plugin back to a known state
+	while (!testPlugin.get_queue_empty())
+	{
+		testPlugin.read_frame(testFrame);
+	}
+	ASSERT_TRUE(testPlugin.get_queue_empty());
+
+	GuidanceInterface interfaceUnderTest(testECU, nullptr); // Configured for broadcasts
+
+	CANHardwareInterface::stop();
+	testPlugin.close();
+}
+
+TEST(GUIDANCE_TESTS, ListenOnlyMode)
+{
+	GuidanceInterface interfaceUnderTest(nullptr, nullptr);
+
+	EXPECT_FALSE(interfaceUnderTest.send_guidance_system_command());
+	EXPECT_FALSE(interfaceUnderTest.send_agricultural_guidance_machine_info());
 }


### PR DESCRIPTION
## What's new

* Added interface for sending and receiving guidance messages.

This PR defines an interface for sending and receiving ISOBUS guidance messages.
These messages are used to steer ISOBUS compliant machines, steering valves, and implements in general.

The interface supports any number of senders of the guidance curvature command message, any number of Agricultural Guidance Machine Info messages, and also supports transmitting both messages.

### Important notes

**Please use extreme care if you try to steer a machine with this interface!** Remember that this library is licensed under The MIT License, and that by obtaining a copy of this library and of course by attempting to steer a machine with it, you are agreeing to our license. The developers of Isobus++ will not help you reverse engineer how to steer any particular machine.

These messages are expected to be deprecated or at least made redundant in favor of Tractor Implement Management (TIM) at some point by the AEF, though the timeline on that is not known at the time of writing this, and it's likely that many machines will continue to support this interface going forward due to its simplicity over TIM. At the time of writing, these messages are widely used and supported.


