### PR TITLE
[VT]: VT server managed working set bugfix

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
@@ -11,9 +11,9 @@
 
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 namespace isobus
 {
@@ -1148,7 +1148,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for an output list object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit OutputList(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit OutputList(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1187,7 +1187,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for an output line object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit OutputLine(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit OutputLine(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1236,7 +1236,7 @@ namespace isobus
 
 		/// @brief Constructor for an output rectangle object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit OutputRectangle(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit OutputRectangle(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1281,7 +1281,7 @@ namespace isobus
 
 		/// @brief Constructor for an output ellipse object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit OutputEllipse(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit OutputEllipse(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1356,7 +1356,7 @@ namespace isobus
 
 		/// @brief Constructor for an output polygon object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit OutputPolygon(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit OutputPolygon(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1410,7 +1410,7 @@ namespace isobus
 
 		/// @brief Constructor for an output meter object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit OutputMeter(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit OutputMeter(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1546,7 +1546,7 @@ namespace isobus
 
 		/// @brief Constructor for an output linear bar graph object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit OutputLinearBarGraph(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit OutputLinearBarGraph(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1674,7 +1674,7 @@ namespace isobus
 
 		/// @brief Constructor for an output arched bar graph object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit OutputArchedBarGraph(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit OutputArchedBarGraph(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1828,7 +1828,7 @@ namespace isobus
 
 		/// @brief Constructor for a picture graphic (bitmap) object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit PictureGraphic(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit PictureGraphic(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1927,7 +1927,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for a number variable object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit NumberVariable(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit NumberVariable(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -1961,7 +1961,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for a string variable object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit StringVariable(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit StringVariable(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -2044,7 +2044,7 @@ namespace isobus
 
 		/// @brief Constructor for a font attributes object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit FontAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit FontAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -2115,7 +2115,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for a line attributes object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit LineAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit LineAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -2158,7 +2158,7 @@ namespace isobus
 
 		/// @brief Constructor for a fill attributes object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit FillAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit FillAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -2201,7 +2201,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for a input attributes object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit InputAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit InputAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -2245,7 +2245,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for an extended input attributes object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit ExtendedInputAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit ExtendedInputAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -2298,7 +2298,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for a object pointer object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit ObjectPointer(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit ObjectPointer(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -2355,7 +2355,7 @@ namespace isobus
 
 		/// @brief Constructor for a macro object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit Macro(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit Macro(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object
@@ -2380,7 +2380,7 @@ namespace isobus
 	public:
 		/// @brief Constructor for a colour map object
 		/// @param[in] parentObjectPool a Pointer to the rest of the object pool this object is a member of
-		explicit ColourMap(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool);
+		explicit ColourMap(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool);
 
 		/// @brief Returns the VT object type of the underlying derived object
 		/// @returns The VT object type of the underlying derived object

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_server_managed_working_set.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_server_managed_working_set.hpp
@@ -118,14 +118,17 @@ namespace isobus
 		/// @brief The object pool processing thread will execute this function when it runs
 		void worker_thread_function();
 
-		std::shared_ptr<std::map<std::uint16_t, VTObject *>> vtObjectTree; ///< The C++ object representation (deserialized) of the object pool being managed
-		std::vector<std::vector<std::uint8_t>> iopFilesRawData; ///< Raw IOP File data from the client
+		std::vector<std::shared_ptr<ControlFunction>> workingSetMemberControlFunctions;
+
+		std::uint16_t workingSetID; ///,< Stores the object ID of the working set object itself
 		std::thread *objectPoolProcessingThread; ///< A thread to process the object pool with, since that can be fairly time consuming.
-		std::mutex manangedWorkingSetMutex; ///< A mutex to protect the interface of the managed working set
 		isobus::ControlFunction *workingSetControlFunction; ///< Stores the control function associated with this working set
 		ObjectPoolProcessingThreadState processingState; ///< Stores the state of processing the object pool
+		
+		std::shared_ptr<std::map<std::uint16_t, VTObject *>> vtObjectTree; ///< The C++ object representation (deserialized) of the object pool being managed
+		std::vector<std::vector<std::uint8_t>> iopFilesRawData; ///< Raw IOP File data from the client
+		std::mutex manangedWorkingSetMutex; ///< A mutex to protect the interface of the managed working set
 		std::uint32_t workingSetMaintenanceMessageTimestamp_ms; ///< A timestamp (in ms) to track sending of the maintenance message
-		std::uint16_t workingSetID; ///,< Stores the object ID of the working set object itself
 		std::uint16_t faultingObjectID; ///< Stores the faulting object ID to send to a client when parsing the pool fails
 	};
 } // namespace isobus

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_server_managed_working_set.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_server_managed_working_set.hpp
@@ -124,7 +124,7 @@ namespace isobus
 		std::thread *objectPoolProcessingThread; ///< A thread to process the object pool with, since that can be fairly time consuming.
 		isobus::ControlFunction *workingSetControlFunction; ///< Stores the control function associated with this working set
 		ObjectPoolProcessingThreadState processingState; ///< Stores the state of processing the object pool
-		
+
 		std::shared_ptr<std::map<std::uint16_t, VTObject *>> vtObjectTree; ///< The C++ object representation (deserialized) of the object pool being managed
 		std::vector<std::vector<std::uint8_t>> iopFilesRawData; ///< Raw IOP File data from the client
 		std::mutex manangedWorkingSetMutex; ///< A mutex to protect the interface of the managed working set

--- a/isobus/src/isobus_virtual_terminal_objects.cpp
+++ b/isobus/src/isobus_virtual_terminal_objects.cpp
@@ -115,7 +115,7 @@ namespace isobus
 	{
 	}
 
-	WorkingSet::WorkingSet(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	WorkingSet::WorkingSet(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool)
 	{
 	}
@@ -259,7 +259,7 @@ namespace isobus
 		        (NULL_OBJECT_ID != objectID));
 	}
 
-	AlarmMask::AlarmMask(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	AlarmMask::AlarmMask(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool)
 	{
 	}
@@ -346,7 +346,7 @@ namespace isobus
 		signalPriority = value;
 	}
 
-	Container::Container(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	Container::Container(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  hidden(false)
 	{
@@ -425,7 +425,7 @@ namespace isobus
 		hidden = value;
 	}
 
-	SoftKeyMask::SoftKeyMask(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	SoftKeyMask::SoftKeyMask(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool)
 	{
 	}
@@ -471,7 +471,7 @@ namespace isobus
 		        (NULL_OBJECT_ID != objectID));
 	}
 
-	Key::Key(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	Key::Key(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  keyCode(0)
 	{
@@ -542,7 +542,7 @@ namespace isobus
 		keyCode = value;
 	}
 
-	KeyGroup::KeyGroup(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	KeyGroup::KeyGroup(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool)
 	{
 	}
@@ -619,7 +619,7 @@ namespace isobus
 		}
 	}
 
-	Button::Button(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	Button::Button(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  borderColour(0),
 	  keyCode(0),
@@ -723,7 +723,7 @@ namespace isobus
 		}
 	}
 
-	InputBoolean::InputBoolean(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	InputBoolean::InputBoolean(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  value(0),
 	  enabled(false)
@@ -789,7 +789,7 @@ namespace isobus
 		enabled = value;
 	}
 
-	InputString::InputString(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	InputString::InputString(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  optionsBitfield(0),
 	  justificationBitfield(0),
@@ -886,7 +886,7 @@ namespace isobus
 		justificationBitfield = value;
 	}
 
-	InputNumber::InputNumber(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	InputNumber::InputNumber(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  scale(0.0f),
 	  maximumValue(0),
@@ -1069,7 +1069,7 @@ namespace isobus
 		value = inputValue;
 	}
 
-	InputList::InputList(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	InputList::InputList(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  numberOfListItems(0),
 	  optionsBitfield(0),
@@ -1149,7 +1149,7 @@ namespace isobus
 		value = inputValue;
 	}
 
-	OutputString::OutputString(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputString::OutputString(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  optionsBitfield(0),
 	  justificationBitfield(0),
@@ -1235,7 +1235,7 @@ namespace isobus
 		stringValue = value;
 	}
 
-	OutputNumber::OutputNumber(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputNumber::OutputNumber(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  scale(0.0f),
 	  offset(0),
@@ -1373,7 +1373,7 @@ namespace isobus
 		value = inputValue;
 	}
 
-	OutputList::OutputList(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputList::OutputList(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  numberOfListItems(0),
 	  value(0)
@@ -1434,7 +1434,7 @@ namespace isobus
 		value = aValue;
 	}
 
-	OutputLine::OutputLine(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputLine::OutputLine(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  lineDirection(0)
 	{
@@ -1488,7 +1488,7 @@ namespace isobus
 		lineDirection = value;
 	}
 
-	OutputRectangle::OutputRectangle(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputRectangle::OutputRectangle(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  lineSuppressionBitfield(0)
 	{
@@ -1544,7 +1544,7 @@ namespace isobus
 		lineSuppressionBitfield = value;
 	}
 
-	OutputEllipse::OutputEllipse(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputEllipse::OutputEllipse(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  ellipseType(0),
 	  startAngle(0),
@@ -1622,7 +1622,7 @@ namespace isobus
 		endAngle = value;
 	}
 
-	OutputPolygon::OutputPolygon(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputPolygon::OutputPolygon(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  polygonType(0)
 	{
@@ -1693,7 +1693,7 @@ namespace isobus
 		polygonType = static_cast<std::uint8_t>(value);
 	}
 
-	OutputMeter::OutputMeter(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputMeter::OutputMeter(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  minValue(0),
 	  maxValue(0),
@@ -1858,7 +1858,7 @@ namespace isobus
 		endAngle = value;
 	}
 
-	OutputLinearBarGraph::OutputLinearBarGraph(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputLinearBarGraph::OutputLinearBarGraph(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  minValue(0),
 	  maxValue(0),
@@ -2013,7 +2013,7 @@ namespace isobus
 		}
 	}
 
-	OutputArchedBarGraph::OutputArchedBarGraph(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	OutputArchedBarGraph::OutputArchedBarGraph(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  barGraphWidth(0),
 	  minValue(0),
@@ -2190,7 +2190,7 @@ namespace isobus
 		targetValueReference = value;
 	}
 
-	PictureGraphic::PictureGraphic(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	PictureGraphic::PictureGraphic(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  numberOfBytesInRawData(0),
 	  actualWidth(0),
@@ -2310,7 +2310,7 @@ namespace isobus
 		transparencyColour = value;
 	}
 
-	NumberVariable::NumberVariable(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	NumberVariable::NumberVariable(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  value(0)
 	{
@@ -2341,7 +2341,7 @@ namespace isobus
 		value = aValue;
 	}
 
-	StringVariable::StringVariable(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	StringVariable::StringVariable(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool)
 	{
 	}
@@ -2371,7 +2371,7 @@ namespace isobus
 		value = aValue;
 	}
 
-	FontAttributes::FontAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	FontAttributes::FontAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  colour(0),
 	  size(0),
@@ -2445,7 +2445,7 @@ namespace isobus
 		colour = value;
 	}
 
-	LineAttributes::LineAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	LineAttributes::LineAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  lineArtBitpattern(0)
 	{
@@ -2476,7 +2476,7 @@ namespace isobus
 		lineArtBitpattern = value;
 	}
 
-	FillAttributes::FillAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	FillAttributes::FillAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  fillPattern(NULL_OBJECT_ID),
 	  type(FillType::NoFill)
@@ -2518,7 +2518,7 @@ namespace isobus
 		type = value;
 	}
 
-	InputAttributes::InputAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	InputAttributes::InputAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  validationType(0)
 	{
@@ -2559,7 +2559,7 @@ namespace isobus
 		validationType = value;
 	}
 
-	ExtendedInputAttributes::ExtendedInputAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	ExtendedInputAttributes::ExtendedInputAttributes(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool),
 	  validationType(0)
 	{
@@ -2600,7 +2600,7 @@ namespace isobus
 		validationType = value;
 	}
 
-	ObjectPointer::ObjectPointer(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	ObjectPointer::ObjectPointer(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool)
 	{
 	}
@@ -2620,7 +2620,7 @@ namespace isobus
 		return true;
 	}
 
-	Macro::Macro(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	Macro::Macro(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool)
 	{
 	}
@@ -2640,7 +2640,7 @@ namespace isobus
 		return true;
 	}
 
-	ColourMap::ColourMap(std::shared_ptr<std::map<std::uint16_t, VTObject *>>parentObjectPool) :
+	ColourMap::ColourMap(std::shared_ptr<std::map<std::uint16_t, VTObject *>> parentObjectPool) :
 	  VTObject(parentObjectPool)
 	{
 	}

--- a/isobus/src/isobus_virtual_terminal_server_managed_working_set.cpp
+++ b/isobus/src/isobus_virtual_terminal_server_managed_working_set.cpp
@@ -34,7 +34,7 @@ namespace isobus
 	  processingState(ObjectPoolProcessingThreadState::None)
 	{
 		initialize_colour_table();
-		
+
 		if (nullptr != associatedControlFunction)
 		{
 			CANStackLogger::info("[WS]: New VT Server Object Created for CF " + isobus::to_string(static_cast<int>(associatedControlFunction->get_NAME().get_full_name())));
@@ -43,12 +43,11 @@ namespace isobus
 		{
 			CANStackLogger::info("[WS]: New VT Server Object Created with no associated control function");
 		}
-		
 	}
 
 	VirtualTerminalServerManagedWorkingSet::~VirtualTerminalServerManagedWorkingSet()
 	{
-		if(nullptr != vtObjectTree)
+		if (nullptr != vtObjectTree)
 		{
 			for (auto key = vtObjectTree->begin(); key != vtObjectTree->end(); ++key)
 			{
@@ -58,7 +57,7 @@ namespace isobus
 					(*key).second = nullptr;
 				}
 			}
-		}		
+		}
 	}
 
 	void VirtualTerminalServerManagedWorkingSet::start_parsing_thread()

--- a/isobus/src/isobus_virtual_terminal_server_managed_working_set.cpp
+++ b/isobus/src/isobus_virtual_terminal_server_managed_working_set.cpp
@@ -15,11 +15,11 @@ namespace isobus
 {
 
 	VirtualTerminalServerManagedWorkingSet::VirtualTerminalServerManagedWorkingSet() :
+	  workingSetID(NULL_OBJECT_ID),
 	  objectPoolProcessingThread(nullptr),
 	  workingSetControlFunction(nullptr),
 	  processingState(ObjectPoolProcessingThreadState::None),
 	  workingSetMaintenanceMessageTimestamp_ms(0),
-	  workingSetID(NULL_OBJECT_ID),
 	  faultingObjectID(NULL_OBJECT_ID)
 	{
 		initialize_colour_table();
@@ -33,6 +33,7 @@ namespace isobus
 	  processingState(ObjectPoolProcessingThreadState::None)
 	{
 		initialize_colour_table();
+		
 		if (nullptr != associatedControlFunction)
 		{
 			CANStackLogger::info("[WS]: New VT Server Object Created for CF " + isobus::to_string(static_cast<int>(associatedControlFunction->get_NAME().get_full_name())));
@@ -41,18 +42,22 @@ namespace isobus
 		{
 			CANStackLogger::info("[WS]: New VT Server Object Created with no associated control function");
 		}
+		
 	}
 
 	VirtualTerminalServerManagedWorkingSet::~VirtualTerminalServerManagedWorkingSet()
 	{
-		for (auto key = vtObjectTree->begin(); key != vtObjectTree->end(); ++key)
+		if(nullptr != vtObjectTree)
 		{
-			if (nullptr != (*key).second)
+			for (auto key = vtObjectTree->begin(); key != vtObjectTree->end(); ++key)
 			{
-				delete (*key).second;
-				(*key).second = nullptr;
+				if (nullptr != (*key).second)
+				{
+					delete (*key).second;
+					(*key).second = nullptr;
+				}
 			}
-		}
+		}		
 	}
 
 	void VirtualTerminalServerManagedWorkingSet::start_parsing_thread()

--- a/isobus/src/isobus_virtual_terminal_server_managed_working_set.cpp
+++ b/isobus/src/isobus_virtual_terminal_server_managed_working_set.cpp
@@ -7,9 +7,10 @@
 /// @copyright 2023 Adrian Del Grosso
 //================================================================================================
 #include "isobus/isobus/isobus_virtual_terminal_server_managed_working_set.hpp"
-
 #include "isobus/isobus/can_stack_logger.hpp"
 #include "isobus/utility/to_string.hpp"
+
+#include <cstring>
 
 namespace isobus
 {


### PR DESCRIPTION
Hi, this is my first pull-request and just a small bug fix that prevents a segmentation fault if the vtObjectTree is a nullptr.
Additionally a warning due to an out-of-order initializier list is fixed.