### PR TITLE
[TP]: Add missing message length for frame chunk callback

### DIFF
--- a/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
@@ -81,6 +81,10 @@ namespace isobus
 			/// @brief A useful way to compare sesson objects to each other for equality
 			bool operator==(const ExtendedTransportProtocolSession &obj);
 
+			/// @brief Get the total number of bytes that will be sent or received in this session
+			/// @return The length of the message in number of bytes
+			std::uint32_t get_message_data_length() const;
+
 		private:
 			friend class ExtendedTransportProtocolManager; ///< Allows the ETP manager full access
 
@@ -96,6 +100,7 @@ namespace isobus
 			CANMessage sessionMessage; ///< A CAN message is used in the session to represent and store data like PGN
 			TransmitCompleteCallback sessionCompleteCallback; ///< A callback that is to be called when the session is completed
 			DataChunkCallback frameChunkCallback; ///< A callback that might be used to get chunks of data to send
+			std::uint32_t frameChunkCallbackMessageLength; ///< The length of the message that is being sent in chunks
 			void *parent; ///< A generic context variable that helps identify what object callbacks are destined for. Can be nullptr
 			std::uint32_t timestamp_ms; ///< A timestamp used to track session timeouts
 			std::uint32_t lastPacketNumber; ///< The last processed sequence number for this set of packets

--- a/isobus/include/isobus/isobus/can_message.hpp
+++ b/isobus/include/isobus/isobus/can_message.hpp
@@ -45,7 +45,7 @@ namespace isobus
 		/// with extended transport protocol is restricted by the extended data packet offset (3 bytes).
 		/// This yields a maximum message size of (2^24-1 packets) x (7 bytes/packet) = 117440505 bytes
 		/// @returns The maximum length of any CAN message as defined by ETP in ISO11783
-		static const std::size_t ABSOLUTE_MAX_MESSAGE_LENGTH = 117440505;
+		static const std::uint32_t ABSOLUTE_MAX_MESSAGE_LENGTH = 117440505;
 
 		/// @brief Constructor for a CAN message
 		/// @param[in] CANPort The can channel index the message uses
@@ -64,7 +64,7 @@ namespace isobus
 
 		/// @brief Returns the length of the data in the CAN message
 		/// @returns The message data payload length
-		virtual std::size_t get_data_length() const;
+		virtual std::uint32_t get_data_length() const;
 
 		/// @brief Gets the source control function that the message is from
 		/// @returns The source control function that the message is from
@@ -85,16 +85,16 @@ namespace isobus
 		/// @brief Sets the message data to the value supplied. Creates a copy.
 		/// @param[in] dataBuffer The data payload
 		/// @param[in] length the length of the data payload in bytes
-		void set_data(const std::uint8_t *dataBuffer, std::size_t length);
+		void set_data(const std::uint8_t *dataBuffer, std::uint32_t length);
 
 		/// @brief Sets one byte of data in the message data payload
 		/// @param[in] dataByte One byte of data
 		/// @param[in] insertPosition The position in the message at which to insert the data byte
-		void set_data(std::uint8_t dataByte, const std::size_t insertPosition);
+		void set_data(std::uint8_t dataByte, const std::uint32_t insertPosition);
 
 		/// @brief Sets the size of the data payload
 		/// @param[in] length The desired length of the data payload
-		void set_data_size(std::size_t length);
+		void set_data_size(std::uint32_t length);
 
 		/// @brief Sets the source control function for the message
 		/// @param[in] value The source control function
@@ -113,7 +113,7 @@ namespace isobus
 		/// @details This function will return the byte at the specified index in the buffer.
 		/// @param[in] index The index to get the byte from
 		/// @return The 8-bit unsigned byte
-		std::uint8_t get_uint8_at(const std::size_t index) const;
+		std::uint8_t get_uint8_at(const std::uint32_t index) const;
 
 		/// @brief Get a 16-bit unsigned integer from the buffer at a specific index.
 		/// A 16-bit unsigned integer can hold a value between 0 and 65535.
@@ -121,7 +121,7 @@ namespace isobus
 		/// @param[in] index The index to get the 16-bit unsigned integer from
 		/// @param[in] format The byte format to use when reading the integer
 		/// @return The 16-bit unsigned integer
-		std::uint16_t get_uint16_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
+		std::uint16_t get_uint16_at(const std::uint32_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
 
 		/// @brief Get a right-aligned 24-bit integer from the buffer (returned as a uint32_t) at a specific index.
 		/// A 24-bit number can hold a value between 0 and 16,777,215.
@@ -129,7 +129,7 @@ namespace isobus
 		/// @param[in] index The index to get the 24-bit unsigned integer from
 		/// @param[in] format The byte format to use when reading the integer
 		/// @return The 24-bit unsigned integer, right aligned into a uint32_t
-		std::uint32_t get_uint24_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
+		std::uint32_t get_uint24_at(const std::uint32_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
 
 		/// @brief Get a 32-bit unsigned integer from the buffer at a specific index.
 		/// A 32-bit unsigned integer can hold a value between 0 and 4294967295.
@@ -137,7 +137,7 @@ namespace isobus
 		/// @param[in] index The index to get the 32-bit unsigned integer from
 		/// @param[in] format The byte format to use when reading the integer
 		/// @return The 32-bit unsigned integer
-		std::uint32_t get_uint32_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
+		std::uint32_t get_uint32_at(const std::uint32_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
 
 		/// @brief Get a 64-bit unsigned integer from the buffer at a specific index.
 		/// A 64-bit unsigned integer can hold a value between 0 and 18446744073709551615.
@@ -145,7 +145,7 @@ namespace isobus
 		/// @param[in] index The index to get the 64-bit unsigned integer from
 		/// @param[in] format The byte format to use when reading the integer
 		/// @return The 64-bit unsigned integer
-		std::uint64_t get_uint64_at(const std::size_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
+		std::uint64_t get_uint64_at(const std::uint32_t index, const ByteFormat format = ByteFormat::LittleEndian) const;
 
 		/// @brief Get a bit-boolean from the buffer at a specific index.
 		/// @details This function will return whether the bit(s) at the specified index in the buffer is/are (all) equal to 1.
@@ -153,7 +153,7 @@ namespace isobus
 		/// @param[in] bitIndex The bit index to start reading the boolean from, ranging from 0 to 7
 		/// @param[in] length The number of bits to read, maximum of (8 - bitIndex)
 		/// @return True if (all) the bit(s) are set, false otherwise
-		bool get_bool_at(const std::size_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length = 1) const;
+		bool get_bool_at(const std::uint32_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length = 1) const;
 
 	private:
 		Type messageType = Type::Receive; ///< The internal message type associated with the message

--- a/isobus/include/isobus/isobus/can_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_transport_protocol.hpp
@@ -64,6 +64,10 @@ namespace isobus
 			/// @brief A useful way to compare sesson objects to each other for equality
 			bool operator==(const TransportProtocolSession &obj);
 
+			/// @brief Get the total number of bytes that will be sent or received in this session
+			/// @return The length of the message in number of bytes
+			std::uint32_t get_message_data_length() const;
+
 		private:
 			friend class TransportProtocolManager; ///< Allows the TP manager full access
 
@@ -79,6 +83,7 @@ namespace isobus
 			CANMessage sessionMessage; ///< A CAN message is used in the session to represent and store data like PGN
 			TransmitCompleteCallback sessionCompleteCallback; ///< A callback that is to be called when the session is completed
 			DataChunkCallback frameChunkCallback; ///< A callback that might be used to get chunks of data to send
+			std::uint32_t frameChunkCallbackMessageLength; ///< The length of the message that is being sent in chunks
 			void *parent; ///< A generic context variable that helps identify what object callbacks are destined for. Can be nullptr
 			std::uint32_t timestamp_ms; ///< A timestamp used to track session timeouts
 			std::uint16_t lastPacketNumber; ///< The last processed sequence number for this set of packets

--- a/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
+++ b/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
@@ -99,6 +99,10 @@ namespace isobus
 			/// @brief A useful way to compare sesson objects to each other for equality
 			bool operator==(const FastPacketProtocolSession &obj);
 
+			/// @brief Get the total number of bytes that will be sent or received in this session
+			/// @return The length of the message in number of bytes
+			std::uint32_t get_message_data_length() const;
+
 		private:
 			friend class FastPacketProtocol; ///< Allows the TP manager full access
 
@@ -113,6 +117,7 @@ namespace isobus
 			CANMessage sessionMessage; ///< A CAN message is used in the session to represent and store data like PGN
 			TransmitCompleteCallback sessionCompleteCallback; ///< A callback that is to be called when the session is completed
 			DataChunkCallback frameChunkCallback; ///< A callback that might be used to get chunks of data to send
+			std::uint32_t frameChunkCallbackMessageLength; ///< The length of the message that is being sent in chunks
 			void *parent; ///< A generic context variable that helps identify what object callbacks are destined for. Can be nullptr
 			std::uint32_t timestamp_ms; ///< A timestamp used to track session timeouts
 			std::uint16_t lastPacketNumber; ///< The last processed sequence number for this set of packets

--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -297,7 +297,7 @@ namespace isobus
 					    (StateMachineState::RxDataSession == tempSession->state) &&
 					    (messageData[SEQUENCE_NUMBER_DATA_INDEX] == (tempSession->lastPacketNumber + 1)))
 					{
-						for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; i < PROTOCOL_BYTES_PER_FRAME; i++)
+						for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; (i < PROTOCOL_BYTES_PER_FRAME) && ((PROTOCOL_BYTES_PER_FRAME * tempSession->lastPacketNumber) + i < tempSession->get_message_data_length()); i++)
 						{
 							std::uint32_t currentDataIndex = (PROTOCOL_BYTES_PER_FRAME * tempSession->processedPacketsThisSession) + i;
 							tempSession->sessionMessage.set_data(messageData[1 + SEQUENCE_NUMBER_DATA_INDEX + i], currentDataIndex);

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -8,6 +8,8 @@
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
 #include "isobus/isobus/can_message.hpp"
+#include "isobus/isobus/can_stack_logger.hpp"
+
 #include <cassert>
 
 namespace isobus
@@ -27,7 +29,7 @@ namespace isobus
 		return data;
 	}
 
-	std::size_t CANMessage::get_data_length() const
+	std::uint32_t CANMessage::get_data_length() const
 	{
 		return data.size();
 	}
@@ -52,23 +54,22 @@ namespace isobus
 		return CANPortIndex;
 	}
 
-	void CANMessage::set_data(const std::uint8_t *dataBuffer, std::size_t length)
+	void CANMessage::set_data(const std::uint8_t *dataBuffer, std::uint32_t length)
 	{
-		if (nullptr != dataBuffer)
-		{
-			data.insert(data.end(), dataBuffer, dataBuffer + length);
-		}
+		assert(length <= ABSOLUTE_MAX_MESSAGE_LENGTH && "CANMessage::set_data() called with length greater than maximum supported");
+		assert(nullptr != dataBuffer && "CANMessage::set_data() called with nullptr dataBuffer");
+
+		data.insert(data.end(), dataBuffer, dataBuffer + length);
 	}
 
-	void CANMessage::set_data(std::uint8_t dataByte, const std::size_t insertPosition)
+	void CANMessage::set_data(std::uint8_t dataByte, const std::uint32_t insertPosition)
 	{
-		if (insertPosition < data.size())
-		{
-			data[insertPosition] = dataByte;
-		}
+		assert(insertPosition <= ABSOLUTE_MAX_MESSAGE_LENGTH && "CANMessage::set_data() called with insertPosition greater than maximum supported");
+
+		data[insertPosition] = dataByte;
 	}
 
-	void CANMessage::set_data_size(std::size_t length)
+	void CANMessage::set_data_size(std::uint32_t length)
 	{
 		data.resize(length);
 	}
@@ -88,12 +89,12 @@ namespace isobus
 		identifier = value;
 	}
 
-	std::uint8_t CANMessage::get_uint8_at(const std::size_t index) const
+	std::uint8_t CANMessage::get_uint8_at(const std::uint32_t index) const
 	{
 		return data.at(index);
 	}
 
-	std::uint16_t CANMessage::get_uint16_at(const std::size_t index, const ByteFormat format) const
+	std::uint16_t CANMessage::get_uint16_at(const std::uint32_t index, const ByteFormat format) const
 	{
 		std::uint16_t retVal;
 		if (ByteFormat::LittleEndian == format)
@@ -109,7 +110,7 @@ namespace isobus
 		return retVal;
 	}
 
-	std::uint32_t CANMessage::get_uint24_at(const std::size_t index, const ByteFormat format) const
+	std::uint32_t CANMessage::get_uint24_at(const std::uint32_t index, const ByteFormat format) const
 	{
 		std::uint32_t retVal;
 		if (ByteFormat::LittleEndian == format)
@@ -127,7 +128,7 @@ namespace isobus
 		return retVal;
 	}
 
-	std::uint32_t CANMessage::get_uint32_at(const std::size_t index, const ByteFormat format) const
+	std::uint32_t CANMessage::get_uint32_at(const std::uint32_t index, const ByteFormat format) const
 	{
 		std::uint32_t retVal;
 		if (ByteFormat::LittleEndian == format)
@@ -147,7 +148,7 @@ namespace isobus
 		return retVal;
 	}
 
-	std::uint64_t CANMessage::get_uint64_at(const std::size_t index, const ByteFormat format) const
+	std::uint64_t CANMessage::get_uint64_at(const std::uint32_t index, const ByteFormat format) const
 	{
 		std::uint64_t retVal;
 		if (ByteFormat::LittleEndian == format)
@@ -174,7 +175,7 @@ namespace isobus
 		}
 		return retVal;
 	}
-	bool isobus::CANMessage::get_bool_at(const std::size_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length) const
+	bool isobus::CANMessage::get_bool_at(const std::uint32_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length) const
 	{
 		assert(length <= 8 - bitIndex && "length must be less than or equal to 8 - bitIndex");
 		std::uint8_t mask = ((1 << length) - 1) << bitIndex;

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -284,7 +284,7 @@ namespace isobus
 						// Check for valid sequence number
 						if (message.get_data()[SEQUENCE_NUMBER_DATA_INDEX] == (tempSession->lastPacketNumber + 1))
 						{
-							for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; i < PROTOCOL_BYTES_PER_FRAME; i++)
+							for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; (i < PROTOCOL_BYTES_PER_FRAME) && ((PROTOCOL_BYTES_PER_FRAME * tempSession->lastPacketNumber) + i < tempSession->get_message_data_length()); i++)
 							{
 								std::uint16_t currentDataIndex = (PROTOCOL_BYTES_PER_FRAME * tempSession->lastPacketNumber) + i;
 								tempSession->sessionMessage.set_data(message.get_data()[1 + SEQUENCE_NUMBER_DATA_INDEX + i], currentDataIndex);


### PR DESCRIPTION
This PR is bugfix for messages being transported by data chunk callbacks using any transport protocol. Their message length was recognized as 0 due to the removal of CANLibManagedMessage in #255.

### Changes:
- Add `frameChunkCallbackMessageLength` to all transporting protocol session classes
- Add utility function `get_message_data_length` to all transporting protocol session classes to determine the correct message length considering both data chunk callbacks and the normal copied message data.
- Also changed the message length/indexes in CANMessage from `size_t` to `uint32_t` as it can't exceed the maximum message length of ETP: 117440505